### PR TITLE
feat: Add OIDC authentication for NuGet publishing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -128,6 +128,9 @@ jobs:
       name: "Production"
       url: "https://www.nuget.org/packages/BenjaminMichaelis.Dotnet.Templates"
     name: Push NuGets
+    permissions:
+      id-token: write   # Required for NuGet trusted publishing (OIDC)
+      contents: read
 
     steps:
       - uses: actions/checkout@v5
@@ -138,6 +141,12 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: NuGet
+
+      - name: NuGet login (OIDC)
+        id: login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USER }}  # nuget.org profile name (NOT email)
 
       - name: Push NuGet
         run: |
@@ -161,5 +170,5 @@ jobs:
            $tagVersion = "$tagVersion-beta.${{ github.run_number }}"
          }
          echo "TAG_VERSION=$tagVersion" >> $env:GITHUB_OUTPUT
-         dotnet nuget push BenjaminMichaelis.Dotnet.Templates.$tagVersion.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+         dotnet nuget push BenjaminMichaelis.Dotnet.Templates.$tagVersion.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --skip-duplicate
         id: tag-version


### PR DESCRIPTION
This pull request updates the GitHub Actions deployment workflow to enable trusted publishing to NuGet.org using OpenID Connect (OIDC) authentication, improving security and automation for publishing NuGet packages. The main changes involve adding OIDC permissions, integrating the `NuGet/login` action, and updating how the API key is provided to the `dotnet nuget push` command.

**Security and authentication improvements:**

* Added OIDC permissions (`id-token: write`, `contents: read`) to the "Push NuGets" job to support trusted publishing with NuGet.org.
* Integrated the `NuGet/login@v1` action to authenticate with NuGet.org using OIDC, replacing the need for a static API key secret.
* Updated the `dotnet nuget push` step to use the API key output from the `NuGet/login` action instead of the repository secret, ensuring credentials are securely managed.