### PR TITLE
Add explicit workflow-level GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: pwsh

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - .github/workflows/copilot-setup-steps.yml
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: pwsh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: '5 10 * * *'
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: pwsh

--- a/templates/Library/NuGet/.github/workflows/build-and-test.yml
+++ b/templates/Library/NuGet/.github/workflows/build-and-test.yml
@@ -10,6 +10,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: pwsh

--- a/templates/Library/NuGet/.github/workflows/copilot-setup-steps.yml
+++ b/templates/Library/NuGet/.github/workflows/copilot-setup-steps.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - .github/workflows/copilot-setup-steps.yml
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: pwsh

--- a/templates/Library/NuGet/.github/workflows/deploy.yml
+++ b/templates/Library/NuGet/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     types: [created]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: pwsh

--- a/templates/Quickstart/BenchmarkApp/.github/workflows/build-and-test.yml
+++ b/templates/Quickstart/BenchmarkApp/.github/workflows/build-and-test.yml
@@ -10,6 +10,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: pwsh

--- a/templates/Quickstart/BenchmarkApp/.github/workflows/copilot-setup-steps.yml
+++ b/templates/Quickstart/BenchmarkApp/.github/workflows/copilot-setup-steps.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - .github/workflows/copilot-setup-steps.yml
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: pwsh

--- a/templates/Quickstart/ConsoleApp/.github/workflows/build-and-test.yml
+++ b/templates/Quickstart/ConsoleApp/.github/workflows/build-and-test.yml
@@ -10,6 +10,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: pwsh

--- a/templates/Quickstart/ConsoleApp/.github/workflows/copilot-setup-steps.yml
+++ b/templates/Quickstart/ConsoleApp/.github/workflows/copilot-setup-steps.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - .github/workflows/copilot-setup-steps.yml
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: pwsh


### PR DESCRIPTION
GitHub Actions reported workflows without explicit `GITHUB_TOKEN` limits. This change applies a consistent minimal baseline so every affected workflow declares token scope explicitly.

## What changed
- Added top-level `permissions` blocks with `contents: read` to the 10 workflows that were missing workflow-level permissions.
- Kept existing job-level permission overrides unchanged (for example, `pull-requests: write`, `contents: write`, and `id-token: write`) so current automation behavior remains intact.
- Applied the same baseline across root workflows and template workflow files for consistency.

## Notes for reviewers
- This is a minimal-risk hardening pass focused only on missing workflow-level permission declarations.
- No functional workflow logic was changed beyond explicit token permission defaults.