### PR TITLE
feat: Add slnx defaults for template solutions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,6 +108,11 @@ jobs:
           if ([bool]::Parse("${{ matrix.expectSln }}") -ne $hasSln) { throw "Unexpected .sln file presence: $hasSln" }
           if ([bool]::Parse("${{ matrix.expectSlnx }}") -ne $hasSlnx) { throw "Unexpected .slnx file presence: $hasSlnx" }
           if ([bool]::Parse("${{ matrix.expectTests }}") -ne $hasTests) { throw "Unexpected test project presence: $hasTests" }
+          $solutionPath = if ($hasSln) { "$projectName.sln" } elseif ($hasSlnx) { "$projectName.slnx" } else { $null }
+          if ($solutionPath) {
+            dotnet restore $solutionPath
+            dotnet build $solutionPath /p:TreatWarningsAsErrors=true
+          }
           if ($hasTests) {
             dotnet test "$projectName.Tests/$projectName.Tests.csproj" /p:TreatWarningsAsErrors=true
           } else {
@@ -168,6 +173,11 @@ jobs:
           if ([bool]::Parse("${{ matrix.expectSln }}") -ne $hasSln) { throw "Unexpected .sln file presence: $hasSln" }
           if ([bool]::Parse("${{ matrix.expectSlnx }}") -ne $hasSlnx) { throw "Unexpected .slnx file presence: $hasSlnx" }
           if ([bool]::Parse("${{ matrix.expectTests }}") -ne $hasTests) { throw "Unexpected test project presence: $hasTests" }
+          $solutionPath = if ($hasSln) { "$projectName.sln" } elseif ($hasSlnx) { "$projectName.slnx" } else { $null }
+          if ($solutionPath) {
+            dotnet restore $solutionPath
+            dotnet build $solutionPath /p:TreatWarningsAsErrors=true
+          }
           if ($hasTests) {
             dotnet test "$projectName.Tests/$projectName.Tests.csproj" /p:TreatWarningsAsErrors=true
           } else {
@@ -224,6 +234,11 @@ jobs:
           if ([bool]::Parse("${{ matrix.expectSln }}") -ne $hasSln) { throw "Unexpected .sln file presence: $hasSln" }
           if ([bool]::Parse("${{ matrix.expectSlnx }}") -ne $hasSlnx) { throw "Unexpected .slnx file presence: $hasSlnx" }
           if ([bool]::Parse("${{ matrix.expectTests }}") -ne $hasTests) { throw "Unexpected test project presence: $hasTests" }
+          $solutionPath = if ($hasSln) { "$projectName.sln" } elseif ($hasSlnx) { "$projectName.slnx" } else { $null }
+          if ($solutionPath) {
+            dotnet restore $solutionPath
+            dotnet build $solutionPath /p:TreatWarningsAsErrors=true
+          }
           if ($hasTests) {
             dotnet test "$projectName.Tests/$projectName.Tests.csproj" /p:TreatWarningsAsErrors=true
           } else {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,11 @@ jobs:
             expectSln: true
             expectSlnx: false
             expectTests: true
+          - variant: sln-no-tests
+            args: "--sln --no-tests"
+            expectSln: true
+            expectSlnx: false
+            expectTests: false
           - variant: no-sln
             args: "--no-sln"
             expectSln: false
@@ -142,6 +147,11 @@ jobs:
             expectSln: true
             expectSlnx: false
             expectTests: true
+          - variant: sln-no-tests
+            args: "--sln --no-tests"
+            expectSln: true
+            expectSlnx: false
+            expectTests: false
           - variant: no-sln
             args: "--no-sln"
             expectSln: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,15 +64,23 @@ jobs:
         include:
           - variant: default
             args: ""
-            expectSolution: true
+            expectSln: false
+            expectSlnx: true
             expectTests: true
           - variant: no-tests
             args: "--no-tests"
-            expectSolution: true
+            expectSln: false
+            expectSlnx: true
             expectTests: false
+          - variant: sln
+            args: "--sln"
+            expectSln: true
+            expectSlnx: false
+            expectTests: true
           - variant: no-sln
             args: "--no-sln"
-            expectSolution: false
+            expectSln: false
+            expectSlnx: false
             expectTests: true
 
     steps:
@@ -94,9 +102,11 @@ jobs:
           Push-Location $outDir
           dotnet new bmichaelis.nuget ${{ matrix.args }}
           $projectName = Split-Path -Leaf (Get-Location)
-          $hasSolution = (Test-Path "$projectName.sln") -or (Test-Path "$projectName.slnx")
+          $hasSln = Test-Path "$projectName.sln"
+          $hasSlnx = Test-Path "$projectName.slnx"
           $hasTests = Test-Path "$projectName.Tests/$projectName.Tests.csproj"
-          if ([bool]::Parse("${{ matrix.expectSolution }}") -ne $hasSolution) { throw "Unexpected solution file presence: $hasSolution" }
+          if ([bool]::Parse("${{ matrix.expectSln }}") -ne $hasSln) { throw "Unexpected .sln file presence: $hasSln" }
+          if ([bool]::Parse("${{ matrix.expectSlnx }}") -ne $hasSlnx) { throw "Unexpected .slnx file presence: $hasSlnx" }
           if ([bool]::Parse("${{ matrix.expectTests }}") -ne $hasTests) { throw "Unexpected test project presence: $hasTests" }
           if ($hasTests) {
             dotnet test "$projectName.Tests/$projectName.Tests.csproj" /p:TreatWarningsAsErrors=true
@@ -114,15 +124,23 @@ jobs:
         include:
           - variant: default
             args: ""
-            expectSolution: true
+            expectSln: false
+            expectSlnx: true
             expectTests: true
           - variant: no-tests
             args: "--no-tests"
-            expectSolution: true
+            expectSln: false
+            expectSlnx: true
             expectTests: false
+          - variant: sln
+            args: "--sln"
+            expectSln: true
+            expectSlnx: false
+            expectTests: true
           - variant: no-sln
             args: "--no-sln"
-            expectSolution: false
+            expectSln: false
+            expectSlnx: false
             expectTests: true
 
     steps:
@@ -144,9 +162,11 @@ jobs:
           Push-Location $outDir
           dotnet new bmichaelis.quickstart.benchmarkconsole ${{ matrix.args }}
           $projectName = Split-Path -Leaf (Get-Location)
-          $hasSolution = (Test-Path "$projectName.sln") -or (Test-Path "$projectName.slnx")
+          $hasSln = Test-Path "$projectName.sln"
+          $hasSlnx = Test-Path "$projectName.slnx"
           $hasTests = Test-Path "$projectName.Tests/$projectName.Tests.csproj"
-          if ([bool]::Parse("${{ matrix.expectSolution }}") -ne $hasSolution) { throw "Unexpected solution file presence: $hasSolution" }
+          if ([bool]::Parse("${{ matrix.expectSln }}") -ne $hasSln) { throw "Unexpected .sln file presence: $hasSln" }
+          if ([bool]::Parse("${{ matrix.expectSlnx }}") -ne $hasSlnx) { throw "Unexpected .slnx file presence: $hasSlnx" }
           if ([bool]::Parse("${{ matrix.expectTests }}") -ne $hasTests) { throw "Unexpected test project presence: $hasTests" }
           if ($hasTests) {
             dotnet test "$projectName.Tests/$projectName.Tests.csproj" /p:TreatWarningsAsErrors=true
@@ -165,15 +185,18 @@ jobs:
         include:
           - variant: default
             args: ""
-            expectSolution: true
+            expectSln: false
+            expectSlnx: true
             expectTests: true
           - variant: no-tests
             args: "--no-tests"
-            expectSolution: true
+            expectSln: false
+            expectSlnx: true
             expectTests: false
           - variant: no-sln
             args: "--no-sln"
-            expectSolution: false
+            expectSln: false
+            expectSlnx: false
             expectTests: true
 
     steps:
@@ -195,9 +218,11 @@ jobs:
           Push-Location $outDir
           dotnet new bmichaelis.quickstart.consoleapp ${{ matrix.args }}
           $projectName = Split-Path -Leaf (Get-Location)
-          $hasSolution = (Test-Path "$projectName.sln") -or (Test-Path "$projectName.slnx")
+          $hasSln = Test-Path "$projectName.sln"
+          $hasSlnx = Test-Path "$projectName.slnx"
           $hasTests = Test-Path "$projectName.Tests/$projectName.Tests.csproj"
-          if ([bool]::Parse("${{ matrix.expectSolution }}") -ne $hasSolution) { throw "Unexpected solution file presence: $hasSolution" }
+          if ([bool]::Parse("${{ matrix.expectSln }}") -ne $hasSln) { throw "Unexpected .sln file presence: $hasSln" }
+          if ([bool]::Parse("${{ matrix.expectSlnx }}") -ne $hasSlnx) { throw "Unexpected .slnx file presence: $hasSlnx" }
           if ([bool]::Parse("${{ matrix.expectTests }}") -ne $hasTests) { throw "Unexpected test project presence: $hasTests" }
           if ($hasTests) {
             dotnet test "$projectName.Tests/$projectName.Tests.csproj" /p:TreatWarningsAsErrors=true

--- a/templates/Library/NuGet/.template.config/template.json
+++ b/templates/Library/NuGet/.template.config/template.json
@@ -35,12 +35,20 @@
     "no-sln": {
       "type": "parameter",
       "dataType":"bool",
-      "defaultValue": "false"
+      "defaultValue": "false",
+      "description": "Do not include a solution file."
+    },
+    "sln": {
+      "type": "parameter",
+      "dataType":"bool",
+      "defaultValue": "false",
+      "description": "Use legacy .sln format instead of the default .slnx format."
     },
     "no-tests": {
       "type": "parameter",
       "dataType":"bool",
-      "defaultValue": "false"
+      "defaultValue": "false",
+      "description": "Do not include a test project."
     }
   },
   "sources": [
@@ -48,6 +56,19 @@
       "modifiers": [
         {
           "condition": "(no-sln)",
+          "exclude": [
+            "NuGetLib.sln",
+            "NuGetLib.slnx"
+          ]
+        },
+        {
+          "condition": "(sln && !no-sln)",
+          "exclude": [
+            "NuGetLib.slnx"
+          ]
+        },
+        {
+          "condition": "(!sln && !no-sln)",
           "exclude": [
             "NuGetLib.sln"
           ]

--- a/templates/Library/NuGet/NuGetLib.sln
+++ b/templates/Library/NuGet/NuGetLib.sln
@@ -5,8 +5,10 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGetLib", "NuGetLib\NuGetLib.csproj", "{A87CB29C-0A36-423F-B9B6-43053906A3CC}"
 EndProject
+#if (!no-tests)
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGetLib.Tests", "NuGetLib.Tests\NuGetLib.Tests.csproj", "{DF8F9490-887C-489E-AFE0-99518CC49ECF}"
 EndProject
+#endif
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{33332FBD-7EFF-4A3D-8691-21BF50B245A7}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
@@ -27,10 +29,12 @@ Global
 		{A87CB29C-0A36-423F-B9B6-43053906A3CC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A87CB29C-0A36-423F-B9B6-43053906A3CC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A87CB29C-0A36-423F-B9B6-43053906A3CC}.Release|Any CPU.Build.0 = Release|Any CPU
+#if (!no-tests)
 		{DF8F9490-887C-489E-AFE0-99518CC49ECF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{DF8F9490-887C-489E-AFE0-99518CC49ECF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DF8F9490-887C-489E-AFE0-99518CC49ECF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DF8F9490-887C-489E-AFE0-99518CC49ECF}.Release|Any CPU.Build.0 = Release|Any CPU
+#endif
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/templates/Library/NuGet/NuGetLib.slnx
+++ b/templates/Library/NuGet/NuGetLib.slnx
@@ -7,6 +7,8 @@
     <File Path="global.json" />
     <File Path="NuGet.config" />
   </Folder>
+<!--#if (!no-tests) -->
   <Project Path="NuGetLib.Tests/NuGetLib.Tests.csproj" />
+<!--#endif -->
   <Project Path="NuGetLib/NuGetLib.csproj" />
 </Solution>

--- a/templates/Library/NuGet/NuGetLib.slnx
+++ b/templates/Library/NuGet/NuGetLib.slnx
@@ -1,0 +1,12 @@
+<Solution>
+  <Folder Name="/Solution Items/">
+    <File Path=".editorconfig" />
+    <File Path="Directory.Build.props" />
+    <File Path="Directory.Build.targets" />
+    <File Path="Directory.Packages.props" />
+    <File Path="global.json" />
+    <File Path="NuGet.config" />
+  </Folder>
+  <Project Path="NuGetLib.Tests/NuGetLib.Tests.csproj" />
+  <Project Path="NuGetLib/NuGetLib.csproj" />
+</Solution>

--- a/templates/Library/NuGet/README.md
+++ b/templates/Library/NuGet/README.md
@@ -23,3 +23,9 @@ Create a new app in your current directory by running.
 1. Create a release on GitHub
 2. Add your [Nuget.org](https://www.nuget.org/account/apikeys) API key to the GitHub repository secrets as `NUGET_API_KEY` with push scope permissions
 3. Tag the release with a tag following a v*.*.*format, likely with*.*.* following a [Semver](https://semver.org/) format. ex: v1.0.0
+
+### Parameters
+
+- `--sln`: Include a legacy `.sln` file instead of the default `.slnx` file.
+- `--no-sln`: Don't include a solution file.
+- `--no-tests`: Don't include the test project.

--- a/templates/Quickstart/BenchmarkApp/.template.config/template.json
+++ b/templates/Quickstart/BenchmarkApp/.template.config/template.json
@@ -35,12 +35,20 @@
     "no-sln": {
       "type": "parameter",
       "dataType":"bool",
-      "defaultValue": "false"
+      "defaultValue": "false",
+      "description": "Do not include a solution file."
+    },
+    "sln": {
+      "type": "parameter",
+      "dataType":"bool",
+      "defaultValue": "false",
+      "description": "Use legacy .sln format instead of the default .slnx format."
     },
     "no-tests": {
       "type": "parameter",
       "dataType":"bool",
-      "defaultValue": "false"
+      "defaultValue": "false",
+      "description": "Do not include a test project."
     }
   },
   "sources": [
@@ -48,6 +56,19 @@
       "modifiers": [
         {
           "condition": "(no-sln)",
+          "exclude": [
+            "BenchmarkApp.sln",
+            "BenchmarkApp.slnx"
+          ]
+        },
+        {
+          "condition": "(sln && !no-sln)",
+          "exclude": [
+            "BenchmarkApp.slnx"
+          ]
+        },
+        {
+          "condition": "(!sln && !no-sln)",
           "exclude": [
             "BenchmarkApp.sln"
           ]

--- a/templates/Quickstart/BenchmarkApp/BenchmarkApp.sln
+++ b/templates/Quickstart/BenchmarkApp/BenchmarkApp.sln
@@ -14,8 +14,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+#if (!no-tests)
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BenchmarkApp.Tests", "BenchmarkApp.Tests\BenchmarkApp.Tests.csproj", "{29ED9E74-DD82-4D2F-99DC-B0865BBF680C}"
 EndProject
+#endif
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BenchmarkApp.Benchmark", "BenchmarkApp.Benchmark\BenchmarkApp.Benchmark.csproj", "{1283065B-D336-4E8A-8507-5731C9550CDD}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BenchmarkApp", "BenchmarkApp\BenchmarkApp.csproj", "{05CD66E2-F93B-478A-AACB-6BD7BCCF9A38}"
@@ -26,10 +28,12 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+#if (!no-tests)
 		{29ED9E74-DD82-4D2F-99DC-B0865BBF680C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{29ED9E74-DD82-4D2F-99DC-B0865BBF680C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{29ED9E74-DD82-4D2F-99DC-B0865BBF680C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{29ED9E74-DD82-4D2F-99DC-B0865BBF680C}.Release|Any CPU.Build.0 = Release|Any CPU
+#endif
 		{1283065B-D336-4E8A-8507-5731C9550CDD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1283065B-D336-4E8A-8507-5731C9550CDD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1283065B-D336-4E8A-8507-5731C9550CDD}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/templates/Quickstart/BenchmarkApp/BenchmarkApp.slnx
+++ b/templates/Quickstart/BenchmarkApp/BenchmarkApp.slnx
@@ -1,0 +1,14 @@
+<Solution>
+  <Folder Name="/Solution Items/">
+    <File Path=".editorconfig" />
+    <File Path="Directory.Build.props" />
+    <File Path="Directory.Build.targets" />
+    <File Path="Directory.Packages.props" />
+    <File Path="global.json" />
+    <File Path="NuGet.config" />
+    <File Path="README.md" />
+  </Folder>
+  <Project Path="BenchmarkApp.Benchmark/BenchmarkApp.Benchmark.csproj" />
+  <Project Path="BenchmarkApp.Tests/BenchmarkApp.Tests.csproj" />
+  <Project Path="BenchmarkApp/BenchmarkApp.csproj" />
+</Solution>

--- a/templates/Quickstart/BenchmarkApp/BenchmarkApp.slnx
+++ b/templates/Quickstart/BenchmarkApp/BenchmarkApp.slnx
@@ -9,6 +9,8 @@
     <File Path="README.md" />
   </Folder>
   <Project Path="BenchmarkApp.Benchmark/BenchmarkApp.Benchmark.csproj" />
+<!--#if (!no-tests) -->
   <Project Path="BenchmarkApp.Tests/BenchmarkApp.Tests.csproj" />
+<!--#endif -->
   <Project Path="BenchmarkApp/BenchmarkApp.csproj" />
 </Solution>

--- a/templates/Quickstart/BenchmarkApp/README.md
+++ b/templates/Quickstart/BenchmarkApp/README.md
@@ -17,6 +17,10 @@ Create a new app in your current directory by running.
 
 ### Parameters
 
+- `--sln`: Include a legacy `.sln` file instead of the default `.slnx` file.
+- `--no-sln`: Don't include a solution file.
+- `--no-tests`: Don't include the test project.
+
 [Default template options](https://learn.microsoft.com/dotnet/core/tools/dotnet-new#options)
 
 ## Key Features

--- a/templates/Quickstart/ConsoleApp/.template.config/template.json
+++ b/templates/Quickstart/ConsoleApp/.template.config/template.json
@@ -35,12 +35,14 @@
     "no-sln": {
       "type": "parameter",
       "dataType":"bool",
-      "defaultValue": "false"
+      "defaultValue": "false",
+      "description": "Do not include a solution file."
     },
     "no-tests": {
       "type": "parameter",
       "dataType":"bool",
-      "defaultValue": "false"
+      "defaultValue": "false",
+      "description": "Do not include a test project."
     }
   },
   "sources": [

--- a/templates/Quickstart/ConsoleApp/README.md
+++ b/templates/Quickstart/ConsoleApp/README.md
@@ -21,7 +21,7 @@ Source:
 
 ### Parameters
 
-- `--no-sln`: Don't include the solution file.
+- `--no-sln`: Don't include the default `.slnx` solution file.
 - `--no-tests`: Don't include the test project.
 
 [Default template options](https://learn.microsoft.com/dotnet/core/tools/dotnet-new#options)
@@ -31,4 +31,3 @@ Source:
 - Simple console app with minimal dependencies.
 - Includes unit tests using xUnit.
 - Ready to build, test, and run.
-- 


### PR DESCRIPTION
This continues the template modernization work by making `.slnx` the default solution format where templates still only emitted legacy `.sln` files, while preserving an opt-in path for users who need `.sln`.

## Summary

- Adds `.slnx` files for the NuGet and Benchmark templates using the SDK solution migration command.
- Makes `.slnx` the default output and adds `--sln` as the opt-in legacy format for those templates.
- Keeps `--no-sln` behavior intact and documents the solution options in template READMEs.
- Expands CI assertions to check `.sln` and `.slnx` presence independently across solution variants.

## Notes

The broader Phase 2 items, including test framework selection and generated CI/CD modernization, remain separate follow-up work.

## Validation

- `dotnet restore`
- `dotnet pack --configuration Release`
- Generated and built NuGet, Benchmark, and ConsoleApp solution variants, including default `.slnx`, `--sln`, and `--no-sln` where supported.