### PR TITLE
feat: Add EF pending-model-changes check to Aspire MinimalApi CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -238,4 +238,6 @@ jobs:
           dotnet new bmichaelis.aspire.minimalapi --name MinimalApi ${{ matrix.args }}
           Push-Location MinimalApi
           dotnet build /p:TreatWarningsAsErrors=true
+          dotnet tool restore
+          dotnet ef migrations has-pending-model-changes --configuration Release --project MinimalApi.Data/MinimalApi.Data.csproj --startup-project MinimalApi.AppHost/MinimalApi.AppHost.csproj --no-build
           dotnet test --no-build /p:TreatWarningsAsErrors=true -p:TestingPlatformDotnetTestSupport=true


### PR DESCRIPTION
Catches un-migrated EF model changes during CI for generated Aspire MinimalApi projects.

The `test-aspire-minimalapi` job now runs two extra steps after `dotnet build`:

1. `dotnet tool restore` -- ensures the `dotnet-ef` tool from the generated project's manifest is available.
2. `dotnet ef migrations has-pending-model-changes --configuration Release --project MinimalApi.Data/MinimalApi.Data.csproj --startup-project MinimalApi.AppHost/MinimalApi.AppHost.csproj --no-build` -- fails the build if the model has diverged from the latest migration snapshot.

Only the Aspire MinimalApi template is affected; the other templates (Library/NuGet, Quickstart/ConsoleApp, Quickstart/BenchmarkApp) do not use EF.