### PR TITLE
feat: Add all-tests gate job to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,3 +239,14 @@ jobs:
           Push-Location MinimalApi
           dotnet build /p:TreatWarningsAsErrors=true
           dotnet test --no-build /p:TreatWarningsAsErrors=true -p:TestingPlatformDotnetTestSupport=true
+
+  all-tests:
+    runs-on: ubuntu-latest
+    needs: [test-library, test-quickstart-benchmarkconsole, test-quickstart-consoleapp, test-aspire-minimalapi]
+    if: always()
+    steps:
+      - name: All tests passed
+        run: |
+          if ("${{ contains(needs.*.result, 'failure') }}" -eq "true" -or "${{ contains(needs.*.result, 'cancelled') }}" -eq "true") {
+            throw "One or more test jobs failed or were cancelled"
+          }


### PR DESCRIPTION
Tracking all matrix variants individually as required status checks in branch protection is tedious -- each new variant must be added manually, and the list grows with every template added.

This adds a single `all-tests` fan-in job that depends on all four test jobs (`test-library`, `test-quickstart-benchmarkconsole`, `test-quickstart-consoleapp`, `test-aspire-minimalapi`). GitHub automatically waits for every matrix variant within those jobs to complete before evaluating `all-tests`.

Key details:
- `if: always()` ensures the gate job runs even when upstream jobs fail, so it shows as a hard failure rather than being skipped.
- The step checks `needs.*.result` for any `failure` or `cancelled` result and throws if found.
- You can now set `all-tests` as the single required status check in branch protection instead of listing every matrix variant.