### PR TITLE
Fix local Aspire telemetry AppInsights dependency

### DIFF
--- a/templates/Aspire/MinimalApi/MinimalApi.AppHost/AppHost.cs
+++ b/templates/Aspire/MinimalApi/MinimalApi.AppHost/AppHost.cs
@@ -17,11 +17,14 @@ IResourceBuilder<IResourceWithConnectionString> db;
 // Application Insights is provisioned by Aspire in Azure and the connection string is
 // injected automatically into all referencing projects as APPLICATIONINSIGHTS_CONNECTION_STRING.
 // Locally, Aspire Dashboard receives all telemetry via OTLP instead.
-var appInsights = builder.AddAzureApplicationInsights("appinsights");
+IResourceBuilder<IResourceWithConnectionString>? appInsights = null;
 //#endif
 
 if (builder.ExecutionContext.IsPublishMode)
 {
+    //#if (applicationInsights)
+    appInsights = builder.AddAzureApplicationInsights("appinsights");
+    //#endif
     db = builder.AddAzureSqlServer().AddDatabase("MinimalApi-db");
 }
 else
@@ -52,11 +55,15 @@ else
 
 var backend = builder.AddProject<Projects.MinimalApi>("MinimalApi-backend")
     .WithDependency(db, ConnectionStrings.DatabaseKey)
-    //#if (applicationInsights)
-    .WithReference(appInsights)
-    //#endif
     .WithExternalHttpEndpoints()
     .PublishAsAzureContainerApp((infra, app) => app.Template.Scale.MaxReplicas = 1);
+
+//#if (applicationInsights)
+if (appInsights is not null)
+{
+    backend.WithReference(appInsights);
+}
+//#endif
 
 if (builder.ExecutionContext.IsPublishMode)
 {


### PR DESCRIPTION
## Why
Local runs of the Aspire MinimalApi template should send telemetry to the Aspire Dashboard via OTLP without requiring Azure credentials. The AppHost was always creating an Azure Application Insights resource and wiring backend dependencies to it, which forced local startup to wait on Azure provisioning.

## What changed
- Made `AddAzureApplicationInsights("appinsights")` publish-mode only in `MinimalApi.AppHost/AppHost.cs`.
- Removed the unconditional backend `.WithReference(appInsights)` from the project builder chain.
- Added a guarded reference so AppInsights is only attached when that resource exists (publish mode).

## Result
Local telemetry flow now stays local (OTLP -> Aspire Dashboard) with no Azure credential requirement, while publish mode still provisions and wires Application Insights for Azure deployments.