### PR TITLE
Enforce strict dotnet format across CI and templates

### DIFF
--- a/.github/scripts/Invoke-DotNetFormatStrict.ps1
+++ b/.github/scripts/Invoke-DotNetFormatStrict.ps1
@@ -1,0 +1,35 @@
+param(
+    [string[]]$Targets,
+    [switch]$DiscoverFromCurrentDirectory,
+    [switch]$RestoreTargets
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not $Targets -or $Targets.Count -eq 0) {
+    if (-not $DiscoverFromCurrentDirectory) {
+        throw 'Specify -Targets or pass -DiscoverFromCurrentDirectory.'
+    }
+
+    $solutionFile = Get-ChildItem -Path . -File | Where-Object { $_.Extension -eq '.sln' -or $_.Extension -eq '.slnx' } | Select-Object -First 1
+    if ($solutionFile) {
+        $Targets = @($solutionFile.FullName)
+    } else {
+        $Targets = @(Get-ChildItem -Path . -Recurse -Filter *.csproj | Select-Object -ExpandProperty FullName)
+    }
+}
+
+if (-not $Targets -or $Targets.Count -eq 0) {
+    throw 'No solution or project files found for format validation.'
+}
+
+foreach ($target in $Targets) {
+    if ($RestoreTargets) {
+        dotnet restore $target
+    }
+
+    dotnet format whitespace $target --verify-no-changes --no-restore
+    dotnet format style $target --verify-no-changes --no-restore --severity info
+    dotnet format analyzers $target --verify-no-changes --no-restore --severity info
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,8 +46,18 @@ jobs:
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
-    - name: Build
-      run: dotnet pack --configuration Release -o . 
+    - name: Restore dependencies
+      run: dotnet restore Templates.csproj
+
+    - name: Enforce formatting
+      run: |
+        $target = "Templates.csproj"
+        dotnet format whitespace $target --verify-no-changes --no-restore
+        dotnet format style $target --verify-no-changes --no-restore --severity info
+        dotnet format analyzers $target --verify-no-changes --no-restore --severity info
+
+    - name: Pack
+      run: dotnet pack --configuration Release --no-restore -o .
     
     - name: Upload Artifacts
       uses: actions/upload-artifact@v7
@@ -98,6 +108,24 @@ jobs:
           $hasTests = Test-Path "$projectName.Tests/$projectName.Tests.csproj"
           if ([bool]::Parse("${{ matrix.expectSolution }}") -ne $hasSolution) { throw "Unexpected solution file presence: $hasSolution" }
           if ([bool]::Parse("${{ matrix.expectTests }}") -ne $hasTests) { throw "Unexpected test project presence: $hasTests" }
+          if ($hasSolution) {
+            $solutionFile = Get-ChildItem -Path . -File | Where-Object { $_.Name -eq "$projectName.sln" -or $_.Name -eq "$projectName.slnx" } | Select-Object -First 1
+            if (-not $solutionFile) { throw "Solution file expected but not found." }
+            $target = $solutionFile.FullName
+            dotnet restore $target
+            dotnet format whitespace $target --verify-no-changes --no-restore
+            dotnet format style $target --verify-no-changes --no-restore --severity info
+            dotnet format analyzers $target --verify-no-changes --no-restore --severity info
+          } else {
+            $projects = @(Get-ChildItem -Path . -Recurse -Filter *.csproj | Select-Object -ExpandProperty FullName)
+            if ($projects.Count -eq 0) { throw "No project files found for format validation." }
+            foreach ($target in $projects) {
+              dotnet restore $target
+              dotnet format whitespace $target --verify-no-changes --no-restore
+              dotnet format style $target --verify-no-changes --no-restore --severity info
+              dotnet format analyzers $target --verify-no-changes --no-restore --severity info
+            }
+          }
           if ($hasTests) {
             dotnet test "$projectName.Tests/$projectName.Tests.csproj" /p:TreatWarningsAsErrors=true
           } else {
@@ -148,6 +176,24 @@ jobs:
           $hasTests = Test-Path "$projectName.Tests/$projectName.Tests.csproj"
           if ([bool]::Parse("${{ matrix.expectSolution }}") -ne $hasSolution) { throw "Unexpected solution file presence: $hasSolution" }
           if ([bool]::Parse("${{ matrix.expectTests }}") -ne $hasTests) { throw "Unexpected test project presence: $hasTests" }
+          if ($hasSolution) {
+            $solutionFile = Get-ChildItem -Path . -File | Where-Object { $_.Name -eq "$projectName.sln" -or $_.Name -eq "$projectName.slnx" } | Select-Object -First 1
+            if (-not $solutionFile) { throw "Solution file expected but not found." }
+            $target = $solutionFile.FullName
+            dotnet restore $target
+            dotnet format whitespace $target --verify-no-changes --no-restore
+            dotnet format style $target --verify-no-changes --no-restore --severity info
+            dotnet format analyzers $target --verify-no-changes --no-restore --severity info
+          } else {
+            $projects = @(Get-ChildItem -Path . -Recurse -Filter *.csproj | Select-Object -ExpandProperty FullName)
+            if ($projects.Count -eq 0) { throw "No project files found for format validation." }
+            foreach ($target in $projects) {
+              dotnet restore $target
+              dotnet format whitespace $target --verify-no-changes --no-restore
+              dotnet format style $target --verify-no-changes --no-restore --severity info
+              dotnet format analyzers $target --verify-no-changes --no-restore --severity info
+            }
+          }
           if ($hasTests) {
             dotnet test "$projectName.Tests/$projectName.Tests.csproj" /p:TreatWarningsAsErrors=true
           } else {
@@ -199,6 +245,24 @@ jobs:
           $hasTests = Test-Path "$projectName.Tests/$projectName.Tests.csproj"
           if ([bool]::Parse("${{ matrix.expectSolution }}") -ne $hasSolution) { throw "Unexpected solution file presence: $hasSolution" }
           if ([bool]::Parse("${{ matrix.expectTests }}") -ne $hasTests) { throw "Unexpected test project presence: $hasTests" }
+          if ($hasSolution) {
+            $solutionFile = Get-ChildItem -Path . -File | Where-Object { $_.Name -eq "$projectName.sln" -or $_.Name -eq "$projectName.slnx" } | Select-Object -First 1
+            if (-not $solutionFile) { throw "Solution file expected but not found." }
+            $target = $solutionFile.FullName
+            dotnet restore $target
+            dotnet format whitespace $target --verify-no-changes --no-restore
+            dotnet format style $target --verify-no-changes --no-restore --severity info
+            dotnet format analyzers $target --verify-no-changes --no-restore --severity info
+          } else {
+            $projects = @(Get-ChildItem -Path . -Recurse -Filter *.csproj | Select-Object -ExpandProperty FullName)
+            if ($projects.Count -eq 0) { throw "No project files found for format validation." }
+            foreach ($target in $projects) {
+              dotnet restore $target
+              dotnet format whitespace $target --verify-no-changes --no-restore
+              dotnet format style $target --verify-no-changes --no-restore --severity info
+              dotnet format analyzers $target --verify-no-changes --no-restore --severity info
+            }
+          }
           if ($hasTests) {
             dotnet test "$projectName.Tests/$projectName.Tests.csproj" /p:TreatWarningsAsErrors=true
           } else {
@@ -237,5 +301,12 @@ jobs:
           Push-Location $outDir
           dotnet new bmichaelis.aspire.minimalapi --name MinimalApi ${{ matrix.args }}
           Push-Location MinimalApi
+          $solutionFile = Get-ChildItem -Path . -File | Where-Object { $_.Extension -eq ".sln" -or $_.Extension -eq ".slnx" } | Select-Object -First 1
+          if (-not $solutionFile) { throw "Expected solution file for Aspire template format validation." }
+          $target = $solutionFile.FullName
+          dotnet restore $target
+          dotnet format whitespace $target --verify-no-changes --no-restore
+          dotnet format style $target --verify-no-changes --no-restore --severity info
+          dotnet format analyzers $target --verify-no-changes --no-restore --severity info
           dotnet build /p:TreatWarningsAsErrors=true
           dotnet test --no-build /p:TreatWarningsAsErrors=true -p:TestingPlatformDotnetTestSupport=true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,10 +51,7 @@ jobs:
 
     - name: Enforce formatting
       run: |
-        $target = "Templates.csproj"
-        dotnet format whitespace $target --verify-no-changes --no-restore
-        dotnet format style $target --verify-no-changes --no-restore --severity info
-        dotnet format analyzers $target --verify-no-changes --no-restore --severity info
+        .\.github\scripts\Invoke-DotNetFormatStrict.ps1 -Targets "Templates.csproj"
 
     - name: Pack
       run: dotnet pack --configuration Release --no-restore -o .
@@ -111,20 +108,9 @@ jobs:
           if ($hasSolution) {
             $solutionFile = Get-ChildItem -Path . -File | Where-Object { $_.Name -eq "$projectName.sln" -or $_.Name -eq "$projectName.slnx" } | Select-Object -First 1
             if (-not $solutionFile) { throw "Solution file expected but not found." }
-            $target = $solutionFile.FullName
-            dotnet restore $target
-            dotnet format whitespace $target --verify-no-changes --no-restore
-            dotnet format style $target --verify-no-changes --no-restore --severity info
-            dotnet format analyzers $target --verify-no-changes --no-restore --severity info
+            .\.github\scripts\Invoke-DotNetFormatStrict.ps1 -Targets $solutionFile.FullName -RestoreTargets
           } else {
-            $projects = @(Get-ChildItem -Path . -Recurse -Filter *.csproj | Select-Object -ExpandProperty FullName)
-            if ($projects.Count -eq 0) { throw "No project files found for format validation." }
-            foreach ($target in $projects) {
-              dotnet restore $target
-              dotnet format whitespace $target --verify-no-changes --no-restore
-              dotnet format style $target --verify-no-changes --no-restore --severity info
-              dotnet format analyzers $target --verify-no-changes --no-restore --severity info
-            }
+            .\.github\scripts\Invoke-DotNetFormatStrict.ps1 -DiscoverFromCurrentDirectory -RestoreTargets
           }
           if ($hasTests) {
             dotnet test "$projectName.Tests/$projectName.Tests.csproj" /p:TreatWarningsAsErrors=true
@@ -179,20 +165,9 @@ jobs:
           if ($hasSolution) {
             $solutionFile = Get-ChildItem -Path . -File | Where-Object { $_.Name -eq "$projectName.sln" -or $_.Name -eq "$projectName.slnx" } | Select-Object -First 1
             if (-not $solutionFile) { throw "Solution file expected but not found." }
-            $target = $solutionFile.FullName
-            dotnet restore $target
-            dotnet format whitespace $target --verify-no-changes --no-restore
-            dotnet format style $target --verify-no-changes --no-restore --severity info
-            dotnet format analyzers $target --verify-no-changes --no-restore --severity info
+            .\.github\scripts\Invoke-DotNetFormatStrict.ps1 -Targets $solutionFile.FullName -RestoreTargets
           } else {
-            $projects = @(Get-ChildItem -Path . -Recurse -Filter *.csproj | Select-Object -ExpandProperty FullName)
-            if ($projects.Count -eq 0) { throw "No project files found for format validation." }
-            foreach ($target in $projects) {
-              dotnet restore $target
-              dotnet format whitespace $target --verify-no-changes --no-restore
-              dotnet format style $target --verify-no-changes --no-restore --severity info
-              dotnet format analyzers $target --verify-no-changes --no-restore --severity info
-            }
+            .\.github\scripts\Invoke-DotNetFormatStrict.ps1 -DiscoverFromCurrentDirectory -RestoreTargets
           }
           if ($hasTests) {
             dotnet test "$projectName.Tests/$projectName.Tests.csproj" /p:TreatWarningsAsErrors=true
@@ -248,20 +223,9 @@ jobs:
           if ($hasSolution) {
             $solutionFile = Get-ChildItem -Path . -File | Where-Object { $_.Name -eq "$projectName.sln" -or $_.Name -eq "$projectName.slnx" } | Select-Object -First 1
             if (-not $solutionFile) { throw "Solution file expected but not found." }
-            $target = $solutionFile.FullName
-            dotnet restore $target
-            dotnet format whitespace $target --verify-no-changes --no-restore
-            dotnet format style $target --verify-no-changes --no-restore --severity info
-            dotnet format analyzers $target --verify-no-changes --no-restore --severity info
+            .\.github\scripts\Invoke-DotNetFormatStrict.ps1 -Targets $solutionFile.FullName -RestoreTargets
           } else {
-            $projects = @(Get-ChildItem -Path . -Recurse -Filter *.csproj | Select-Object -ExpandProperty FullName)
-            if ($projects.Count -eq 0) { throw "No project files found for format validation." }
-            foreach ($target in $projects) {
-              dotnet restore $target
-              dotnet format whitespace $target --verify-no-changes --no-restore
-              dotnet format style $target --verify-no-changes --no-restore --severity info
-              dotnet format analyzers $target --verify-no-changes --no-restore --severity info
-            }
+            .\.github\scripts\Invoke-DotNetFormatStrict.ps1 -DiscoverFromCurrentDirectory -RestoreTargets
           }
           if ($hasTests) {
             dotnet test "$projectName.Tests/$projectName.Tests.csproj" /p:TreatWarningsAsErrors=true
@@ -303,11 +267,7 @@ jobs:
           Push-Location MinimalApi
           $solutionFile = Get-ChildItem -Path . -File | Where-Object { $_.Extension -eq ".sln" -or $_.Extension -eq ".slnx" } | Select-Object -First 1
           if (-not $solutionFile) { throw "Expected solution file for Aspire template format validation." }
-          $target = $solutionFile.FullName
-          dotnet restore $target
-          dotnet format whitespace $target --verify-no-changes --no-restore
-          dotnet format style $target --verify-no-changes --no-restore --severity info
-          dotnet format analyzers $target --verify-no-changes --no-restore --severity info
+          .\.github\scripts\Invoke-DotNetFormatStrict.ps1 -Targets $solutionFile.FullName -RestoreTargets
           dotnet build /p:TreatWarningsAsErrors=true
           dotnet tool restore
           dotnet ef migrations has-pending-model-changes --configuration Release --project MinimalApi.Data/MinimalApi.Data.csproj --startup-project MinimalApi.AppHost/MinimalApi.AppHost.csproj --no-build

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ When done, you can remove the local install of the template package by running:
 - [ ] Add project under the template directory
 - [ ] Update .template.config in directory
 - [ ] Copy root .editorconfig to template directory (or run `./CopyEditorConfigToTemplates.ps1`)
+- [ ] Ensure template CI includes strict `dotnet format` checks (whitespace, style, analyzers)
 - [ ] Update dependabot.yml
 - [ ] Update build.yml workflow
 - [ ] Add to README
@@ -84,6 +85,11 @@ When done, you can remove the local install of the template package by running:
 ### EditorConfig Management
 
 Each template includes an `.editorconfig` file that is based on the root repository's `.editorconfig`. This ensures consistent coding standards across all generated projects.
+
+CI enforces formatting via strict checks:
+- `dotnet format whitespace <target> --verify-no-changes --no-restore`
+- `dotnet format style <target> --verify-no-changes --no-restore --severity info`
+- `dotnet format analyzers <target> --verify-no-changes --no-restore --severity info`
 
 **For new templates:**
 - Copy the root `.editorconfig` to your template directory

--- a/templates/Aspire/MinimalApi/.github/scripts/Invoke-DotNetFormatStrict.ps1
+++ b/templates/Aspire/MinimalApi/.github/scripts/Invoke-DotNetFormatStrict.ps1
@@ -1,0 +1,35 @@
+param(
+    [string[]]$Targets,
+    [switch]$DiscoverFromCurrentDirectory,
+    [switch]$RestoreTargets
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not $Targets -or $Targets.Count -eq 0) {
+    if (-not $DiscoverFromCurrentDirectory) {
+        throw 'Specify -Targets or pass -DiscoverFromCurrentDirectory.'
+    }
+
+    $solutionFile = Get-ChildItem -Path . -File | Where-Object { $_.Extension -eq '.sln' -or $_.Extension -eq '.slnx' } | Select-Object -First 1
+    if ($solutionFile) {
+        $Targets = @($solutionFile.FullName)
+    } else {
+        $Targets = @(Get-ChildItem -Path . -Recurse -Filter *.csproj | Select-Object -ExpandProperty FullName)
+    }
+}
+
+if (-not $Targets -or $Targets.Count -eq 0) {
+    throw 'No solution or project files found for format validation.'
+}
+
+foreach ($target in $Targets) {
+    if ($RestoreTargets) {
+        dotnet restore $target
+    }
+
+    dotnet format whitespace $target --verify-no-changes --no-restore
+    dotnet format style $target --verify-no-changes --no-restore --severity info
+    dotnet format analyzers $target --verify-no-changes --no-restore --severity info
+}

--- a/templates/Aspire/MinimalApi/.github/workflows/build-and-deploy.yml
+++ b/templates/Aspire/MinimalApi/.github/workflows/build-and-deploy.yml
@@ -42,21 +42,7 @@ jobs:
 
       - name: Enforce formatting
         run: |
-          $solutionFile = Get-ChildItem -Path . -File | Where-Object { $_.Extension -eq ".sln" -or $_.Extension -eq ".slnx" } | Select-Object -First 1
-          if ($solutionFile) {
-            $target = $solutionFile.FullName
-            dotnet format whitespace $target --verify-no-changes --no-restore
-            dotnet format style $target --verify-no-changes --no-restore --severity info
-            dotnet format analyzers $target --verify-no-changes --no-restore --severity info
-          } else {
-            $projects = @(Get-ChildItem -Path . -Recurse -Filter *.csproj | Select-Object -ExpandProperty FullName)
-            if ($projects.Count -eq 0) { throw "No project files found for format validation." }
-            foreach ($target in $projects) {
-              dotnet format whitespace $target --verify-no-changes --no-restore
-              dotnet format style $target --verify-no-changes --no-restore --severity info
-              dotnet format analyzers $target --verify-no-changes --no-restore --severity info
-            }
-          }
+          .\.github\scripts\Invoke-DotNetFormatStrict.ps1 -DiscoverFromCurrentDirectory
  
       - name: Build
         run: dotnet build --no-restore --configuration Release

--- a/templates/Aspire/MinimalApi/.github/workflows/build-and-deploy.yml
+++ b/templates/Aspire/MinimalApi/.github/workflows/build-and-deploy.yml
@@ -40,6 +40,24 @@ jobs:
       - name: Restore .NET dependencies
         run: dotnet restore
 
+      - name: Enforce formatting
+        run: |
+          $solutionFile = Get-ChildItem -Path . -File | Where-Object { $_.Extension -eq ".sln" -or $_.Extension -eq ".slnx" } | Select-Object -First 1
+          if ($solutionFile) {
+            $target = $solutionFile.FullName
+            dotnet format whitespace $target --verify-no-changes --no-restore
+            dotnet format style $target --verify-no-changes --no-restore --severity info
+            dotnet format analyzers $target --verify-no-changes --no-restore --severity info
+          } else {
+            $projects = @(Get-ChildItem -Path . -Recurse -Filter *.csproj | Select-Object -ExpandProperty FullName)
+            if ($projects.Count -eq 0) { throw "No project files found for format validation." }
+            foreach ($target in $projects) {
+              dotnet format whitespace $target --verify-no-changes --no-restore
+              dotnet format style $target --verify-no-changes --no-restore --severity info
+              dotnet format analyzers $target --verify-no-changes --no-restore --severity info
+            }
+          }
+ 
       - name: Build
         run: dotnet build --no-restore --configuration Release
 

--- a/templates/Library/NuGet/.github/scripts/Invoke-DotNetFormatStrict.ps1
+++ b/templates/Library/NuGet/.github/scripts/Invoke-DotNetFormatStrict.ps1
@@ -1,0 +1,35 @@
+param(
+    [string[]]$Targets,
+    [switch]$DiscoverFromCurrentDirectory,
+    [switch]$RestoreTargets
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not $Targets -or $Targets.Count -eq 0) {
+    if (-not $DiscoverFromCurrentDirectory) {
+        throw 'Specify -Targets or pass -DiscoverFromCurrentDirectory.'
+    }
+
+    $solutionFile = Get-ChildItem -Path . -File | Where-Object { $_.Extension -eq '.sln' -or $_.Extension -eq '.slnx' } | Select-Object -First 1
+    if ($solutionFile) {
+        $Targets = @($solutionFile.FullName)
+    } else {
+        $Targets = @(Get-ChildItem -Path . -Recurse -Filter *.csproj | Select-Object -ExpandProperty FullName)
+    }
+}
+
+if (-not $Targets -or $Targets.Count -eq 0) {
+    throw 'No solution or project files found for format validation.'
+}
+
+foreach ($target in $Targets) {
+    if ($RestoreTargets) {
+        dotnet restore $target
+    }
+
+    dotnet format whitespace $target --verify-no-changes --no-restore
+    dotnet format style $target --verify-no-changes --no-restore --severity info
+    dotnet format analyzers $target --verify-no-changes --no-restore --severity info
+}

--- a/templates/Library/NuGet/.github/workflows/build-and-test.yml
+++ b/templates/Library/NuGet/.github/workflows/build-and-test.yml
@@ -52,21 +52,7 @@ jobs:
 
       - name: Enforce formatting
         run: |
-          $solutionFile = Get-ChildItem -Path . -File | Where-Object { $_.Extension -eq ".sln" -or $_.Extension -eq ".slnx" } | Select-Object -First 1
-          if ($solutionFile) {
-            $target = $solutionFile.FullName
-            dotnet format whitespace $target --verify-no-changes --no-restore
-            dotnet format style $target --verify-no-changes --no-restore --severity info
-            dotnet format analyzers $target --verify-no-changes --no-restore --severity info
-          } else {
-            $projects = @(Get-ChildItem -Path . -Recurse -Filter *.csproj | Select-Object -ExpandProperty FullName)
-            if ($projects.Count -eq 0) { throw "No project files found for format validation." }
-            foreach ($target in $projects) {
-              dotnet format whitespace $target --verify-no-changes --no-restore
-              dotnet format style $target --verify-no-changes --no-restore --severity info
-              dotnet format analyzers $target --verify-no-changes --no-restore --severity info
-            }
-          }
+          .\.github\scripts\Invoke-DotNetFormatStrict.ps1 -DiscoverFromCurrentDirectory
   
       - name: Build
         run: dotnet build -p:ContinuousIntegrationBuild=True --no-restore --configuration Release

--- a/templates/Library/NuGet/.github/workflows/build-and-test.yml
+++ b/templates/Library/NuGet/.github/workflows/build-and-test.yml
@@ -49,6 +49,24 @@ jobs:
   
       - name: Restore dependencies
         run: dotnet restore
+
+      - name: Enforce formatting
+        run: |
+          $solutionFile = Get-ChildItem -Path . -File | Where-Object { $_.Extension -eq ".sln" -or $_.Extension -eq ".slnx" } | Select-Object -First 1
+          if ($solutionFile) {
+            $target = $solutionFile.FullName
+            dotnet format whitespace $target --verify-no-changes --no-restore
+            dotnet format style $target --verify-no-changes --no-restore --severity info
+            dotnet format analyzers $target --verify-no-changes --no-restore --severity info
+          } else {
+            $projects = @(Get-ChildItem -Path . -Recurse -Filter *.csproj | Select-Object -ExpandProperty FullName)
+            if ($projects.Count -eq 0) { throw "No project files found for format validation." }
+            foreach ($target in $projects) {
+              dotnet format whitespace $target --verify-no-changes --no-restore
+              dotnet format style $target --verify-no-changes --no-restore --severity info
+              dotnet format analyzers $target --verify-no-changes --no-restore --severity info
+            }
+          }
   
       - name: Build
         run: dotnet build -p:ContinuousIntegrationBuild=True --no-restore --configuration Release

--- a/templates/Library/NuGet/NuGetLib/Class1.cs
+++ b/templates/Library/NuGet/NuGetLib/Class1.cs
@@ -1,4 +1,4 @@
-﻿namespace NuGetLib;
+namespace NuGetLib;
 
 /// <summary>
 /// Class1

--- a/templates/Quickstart/BenchmarkApp/.github/scripts/Invoke-DotNetFormatStrict.ps1
+++ b/templates/Quickstart/BenchmarkApp/.github/scripts/Invoke-DotNetFormatStrict.ps1
@@ -1,0 +1,35 @@
+param(
+    [string[]]$Targets,
+    [switch]$DiscoverFromCurrentDirectory,
+    [switch]$RestoreTargets
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not $Targets -or $Targets.Count -eq 0) {
+    if (-not $DiscoverFromCurrentDirectory) {
+        throw 'Specify -Targets or pass -DiscoverFromCurrentDirectory.'
+    }
+
+    $solutionFile = Get-ChildItem -Path . -File | Where-Object { $_.Extension -eq '.sln' -or $_.Extension -eq '.slnx' } | Select-Object -First 1
+    if ($solutionFile) {
+        $Targets = @($solutionFile.FullName)
+    } else {
+        $Targets = @(Get-ChildItem -Path . -Recurse -Filter *.csproj | Select-Object -ExpandProperty FullName)
+    }
+}
+
+if (-not $Targets -or $Targets.Count -eq 0) {
+    throw 'No solution or project files found for format validation.'
+}
+
+foreach ($target in $Targets) {
+    if ($RestoreTargets) {
+        dotnet restore $target
+    }
+
+    dotnet format whitespace $target --verify-no-changes --no-restore
+    dotnet format style $target --verify-no-changes --no-restore --severity info
+    dotnet format analyzers $target --verify-no-changes --no-restore --severity info
+}

--- a/templates/Quickstart/BenchmarkApp/.github/workflows/build-and-test.yml
+++ b/templates/Quickstart/BenchmarkApp/.github/workflows/build-and-test.yml
@@ -52,21 +52,7 @@ jobs:
 
       - name: Enforce formatting
         run: |
-          $solutionFile = Get-ChildItem -Path . -File | Where-Object { $_.Extension -eq ".sln" -or $_.Extension -eq ".slnx" } | Select-Object -First 1
-          if ($solutionFile) {
-            $target = $solutionFile.FullName
-            dotnet format whitespace $target --verify-no-changes --no-restore
-            dotnet format style $target --verify-no-changes --no-restore --severity info
-            dotnet format analyzers $target --verify-no-changes --no-restore --severity info
-          } else {
-            $projects = @(Get-ChildItem -Path . -Recurse -Filter *.csproj | Select-Object -ExpandProperty FullName)
-            if ($projects.Count -eq 0) { throw "No project files found for format validation." }
-            foreach ($target in $projects) {
-              dotnet format whitespace $target --verify-no-changes --no-restore
-              dotnet format style $target --verify-no-changes --no-restore --severity info
-              dotnet format analyzers $target --verify-no-changes --no-restore --severity info
-            }
-          }
+          .\.github\scripts\Invoke-DotNetFormatStrict.ps1 -DiscoverFromCurrentDirectory
   
       - name: Build
         run: dotnet build -p:ContinuousIntegrationBuild=True --no-restore --configuration Release

--- a/templates/Quickstart/BenchmarkApp/.github/workflows/build-and-test.yml
+++ b/templates/Quickstart/BenchmarkApp/.github/workflows/build-and-test.yml
@@ -49,6 +49,24 @@ jobs:
   
       - name: Restore dependencies
         run: dotnet restore
+
+      - name: Enforce formatting
+        run: |
+          $solutionFile = Get-ChildItem -Path . -File | Where-Object { $_.Extension -eq ".sln" -or $_.Extension -eq ".slnx" } | Select-Object -First 1
+          if ($solutionFile) {
+            $target = $solutionFile.FullName
+            dotnet format whitespace $target --verify-no-changes --no-restore
+            dotnet format style $target --verify-no-changes --no-restore --severity info
+            dotnet format analyzers $target --verify-no-changes --no-restore --severity info
+          } else {
+            $projects = @(Get-ChildItem -Path . -Recurse -Filter *.csproj | Select-Object -ExpandProperty FullName)
+            if ($projects.Count -eq 0) { throw "No project files found for format validation." }
+            foreach ($target in $projects) {
+              dotnet format whitespace $target --verify-no-changes --no-restore
+              dotnet format style $target --verify-no-changes --no-restore --severity info
+              dotnet format analyzers $target --verify-no-changes --no-restore --severity info
+            }
+          }
   
       - name: Build
         run: dotnet build -p:ContinuousIntegrationBuild=True --no-restore --configuration Release

--- a/templates/Quickstart/ConsoleApp/.github/scripts/Invoke-DotNetFormatStrict.ps1
+++ b/templates/Quickstart/ConsoleApp/.github/scripts/Invoke-DotNetFormatStrict.ps1
@@ -1,0 +1,35 @@
+param(
+    [string[]]$Targets,
+    [switch]$DiscoverFromCurrentDirectory,
+    [switch]$RestoreTargets
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not $Targets -or $Targets.Count -eq 0) {
+    if (-not $DiscoverFromCurrentDirectory) {
+        throw 'Specify -Targets or pass -DiscoverFromCurrentDirectory.'
+    }
+
+    $solutionFile = Get-ChildItem -Path . -File | Where-Object { $_.Extension -eq '.sln' -or $_.Extension -eq '.slnx' } | Select-Object -First 1
+    if ($solutionFile) {
+        $Targets = @($solutionFile.FullName)
+    } else {
+        $Targets = @(Get-ChildItem -Path . -Recurse -Filter *.csproj | Select-Object -ExpandProperty FullName)
+    }
+}
+
+if (-not $Targets -or $Targets.Count -eq 0) {
+    throw 'No solution or project files found for format validation.'
+}
+
+foreach ($target in $Targets) {
+    if ($RestoreTargets) {
+        dotnet restore $target
+    }
+
+    dotnet format whitespace $target --verify-no-changes --no-restore
+    dotnet format style $target --verify-no-changes --no-restore --severity info
+    dotnet format analyzers $target --verify-no-changes --no-restore --severity info
+}

--- a/templates/Quickstart/ConsoleApp/.github/workflows/build-and-test.yml
+++ b/templates/Quickstart/ConsoleApp/.github/workflows/build-and-test.yml
@@ -52,21 +52,7 @@ jobs:
 
       - name: Enforce formatting
         run: |
-          $solutionFile = Get-ChildItem -Path . -File | Where-Object { $_.Extension -eq ".sln" -or $_.Extension -eq ".slnx" } | Select-Object -First 1
-          if ($solutionFile) {
-            $target = $solutionFile.FullName
-            dotnet format whitespace $target --verify-no-changes --no-restore
-            dotnet format style $target --verify-no-changes --no-restore --severity info
-            dotnet format analyzers $target --verify-no-changes --no-restore --severity info
-          } else {
-            $projects = @(Get-ChildItem -Path . -Recurse -Filter *.csproj | Select-Object -ExpandProperty FullName)
-            if ($projects.Count -eq 0) { throw "No project files found for format validation." }
-            foreach ($target in $projects) {
-              dotnet format whitespace $target --verify-no-changes --no-restore
-              dotnet format style $target --verify-no-changes --no-restore --severity info
-              dotnet format analyzers $target --verify-no-changes --no-restore --severity info
-            }
-          }
+          .\.github\scripts\Invoke-DotNetFormatStrict.ps1 -DiscoverFromCurrentDirectory
   
       - name: Build
         run: dotnet build -p:ContinuousIntegrationBuild=True --no-restore --configuration Release

--- a/templates/Quickstart/ConsoleApp/.github/workflows/build-and-test.yml
+++ b/templates/Quickstart/ConsoleApp/.github/workflows/build-and-test.yml
@@ -49,6 +49,24 @@ jobs:
   
       - name: Restore dependencies
         run: dotnet restore
+
+      - name: Enforce formatting
+        run: |
+          $solutionFile = Get-ChildItem -Path . -File | Where-Object { $_.Extension -eq ".sln" -or $_.Extension -eq ".slnx" } | Select-Object -First 1
+          if ($solutionFile) {
+            $target = $solutionFile.FullName
+            dotnet format whitespace $target --verify-no-changes --no-restore
+            dotnet format style $target --verify-no-changes --no-restore --severity info
+            dotnet format analyzers $target --verify-no-changes --no-restore --severity info
+          } else {
+            $projects = @(Get-ChildItem -Path . -Recurse -Filter *.csproj | Select-Object -ExpandProperty FullName)
+            if ($projects.Count -eq 0) { throw "No project files found for format validation." }
+            foreach ($target in $projects) {
+              dotnet format whitespace $target --verify-no-changes --no-restore
+              dotnet format style $target --verify-no-changes --no-restore --severity info
+              dotnet format analyzers $target --verify-no-changes --no-restore --severity info
+            }
+          }
   
       - name: Build
         run: dotnet build -p:ContinuousIntegrationBuild=True --no-restore --configuration Release

--- a/templates/Quickstart/ConsoleApp/ConsoleApp/Program.cs
+++ b/templates/Quickstart/ConsoleApp/ConsoleApp/Program.cs
@@ -1,4 +1,4 @@
-﻿namespace ConsoleApp.Console;
+namespace ConsoleApp.Console;
 
 public sealed class Program
 {


### PR DESCRIPTION
This change closes a gap where formatting drift could pass CI in both the template pack repository and generated template projects. We now enforce consistent formatting behavior from `.editorconfig` across all relevant CI paths.

## What changed
- Added strict format enforcement to root CI in `.github/workflows/build.yml`:
  - `dotnet format whitespace ... --verify-no-changes`
  - `dotnet format style ... --verify-no-changes --severity info`
  - `dotnet format analyzers ... --verify-no-changes --severity info`
- Extended generated-template validation matrix jobs in the root workflow to run the same strict format profile per variant before build/test.
  - Uses solution targets when present.
  - Falls back to per-project targets for `--no-sln` variants.
- Added the same strict format enforcement to template-owned CI workflows:
  - `templates/Library/NuGet/.github/workflows/build-and-test.yml`
  - `templates/Quickstart/ConsoleApp/.github/workflows/build-and-test.yml`
  - `templates/Quickstart/BenchmarkApp/.github/workflows/build-and-test.yml`
  - `templates/Aspire/MinimalApi/.github/workflows/build-and-deploy.yml`
- Updated `README.md` template checklist and formatting guidance to document strict CI enforcement.
- Normalized two template source files so they comply with the strict format checks.

## Notes for reviewers
The intentional strictness here is `--severity info` for style/analyzers, so suggestions are enforced in CI rather than only warnings/errors. This is deliberate to keep generated output and template sources consistently aligned with `.editorconfig`.