### PR TITLE
Fix Aspire MinimalApi startup on macOS

### DIFF
--- a/templates/Aspire/MinimalApi/MinimalApi.AppHost/AppHost.cs
+++ b/templates/Aspire/MinimalApi/MinimalApi.AppHost/AppHost.cs
@@ -10,6 +10,7 @@ builder.AddAzureContainerAppEnvironment("MinimalApi-cae");
 var docsGroup = builder.AddLogicalGroup("docs");
 builder.AddAspireDocs().WithParentRelationship(docsGroup);
 builder.AddMUIDocs().WithParentRelationship(docsGroup);
+var authSigningKey = builder.AddParameter("auth-signing-key", secret: true);
 
 IResourceBuilder<IResourceWithConnectionString> db;
 
@@ -52,6 +53,7 @@ else
 
 var backend = builder.AddProject<Projects.MinimalApi>("MinimalApi-backend")
     .WithDependency(db, ConnectionStrings.DatabaseKey)
+    .WithEnvironment("Auth__SigningKey", authSigningKey)
     //#if (applicationInsights)
     .WithReference(appInsights)
     //#endif

--- a/templates/Aspire/MinimalApi/MinimalApi/Program.cs
+++ b/templates/Aspire/MinimalApi/MinimalApi/Program.cs
@@ -19,7 +19,10 @@ builder.AddServiceDefaults()
 // NOTE: Do NOT also call AddApplicationInsightsTelemetry() - that is the classic AI SDK and would
 // double-report telemetry. The Azure Monitor OTel exporter (UseAzureMonitor in ServiceDefaults) is
 // the sole App Insights integration path in this template.
-builder.Services.AddServiceProfiler();
+if (OperatingSystem.IsWindows() || OperatingSystem.IsLinux())
+{
+    builder.Services.AddServiceProfiler();
+}
 //#endif
 
 // Add services to the container.

--- a/templates/Aspire/MinimalApi/README.md
+++ b/templates/Aspire/MinimalApi/README.md
@@ -42,6 +42,13 @@ With Application Insights monitoring enabled:
 > aspire run
 ```
 
+The AppHost passes the backend auth signing key through a secret parameter (`Auth__SigningKey`).
+Set it once for local development:
+
+```cli
+> aspire secret set Parameters:auth-signing-key "<at-least-32-char-secret>"
+```
+
 ## Container / Docker
 
 A `Dockerfile` is included in `MinimalApi/` for building the API image outside of Aspire (CI/CD pipelines, Docker Compose, manual builds).
@@ -83,7 +90,7 @@ When the template is generated with `--applicationInsights true`, the following 
 |---|---|
 | `Aspire.Hosting.Azure.ApplicationInsights` | Aspire provisions an AI resource in Azure and injects `APPLICATIONINSIGHTS_CONNECTION_STRING` automatically into the API container |
 | `Microsoft.ApplicationInsights.Profiler.AspNetCore` | CPU flame-graph profiler; uploads traces to App Insights Performance blade |
-| `builder.Services.AddServiceProfiler()` | Registers the profiler (no-op locally when no connection string is present) |
+| `builder.Services.AddServiceProfiler()` | Registers the profiler on Windows/Linux (skipped on unsupported platforms such as macOS) |
 
 ### How this works with Aspire's built-in telemetry
 


### PR DESCRIPTION
## Why
The Aspire Minimal API template failed on macOS local startup for two reasons: profiler registration ran on an unsupported platform, and the API required `Auth:SigningKey` without AppHost providing it by default.

## What changed
- Added an OS guard in `MinimalApi/Program.cs` so `AddServiceProfiler()` only registers on Windows/Linux.
- Added an AppHost secret parameter (`auth-signing-key`) and wired it to the backend as `Auth__SigningKey`.
- Updated the template README to document setting the local Aspire secret and clarified profiler platform behavior.

## Notes
- The API still enforces signing-key presence and minimum length, so auth remains fail-fast and explicit.
- This keeps standalone Docker behavior unchanged: users still pass `Auth__SigningKey` at runtime.