### PR TITLE
feat: Migrate Aspire MinimalApi docs to native OpenAPI + Scalar

### DIFF
--- a/templates/Aspire/MinimalApi/Directory.Packages.props
+++ b/templates/Aspire/MinimalApi/Directory.Packages.props
@@ -15,6 +15,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.8" />
@@ -33,7 +34,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageVersion Include="Polly.Core" Version="8.6.6" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.7" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.14.14" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
     <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.7.2" />
   </ItemGroup>

--- a/templates/Aspire/MinimalApi/MinimalApi/MinimalApi.csproj
+++ b/templates/Aspire/MinimalApi/MinimalApi/MinimalApi.csproj
@@ -9,7 +9,8 @@
     <ProjectReference Include="..\MinimalApi.Data\MinimalApi.Data.csproj" />
     <ProjectReference Include="..\MinimalApi.ServiceDefaults\MinimalApi.ServiceDefaults.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
-    <PackageReference Include="Swashbuckle.AspNetCore" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="Scalar.AspNetCore" />
     <!--#if (applicationInsights)-->
     <PackageReference Include="Microsoft.ApplicationInsights.Profiler.AspNetCore" />
     <!--#endif-->

--- a/templates/Aspire/MinimalApi/MinimalApi/Program.cs
+++ b/templates/Aspire/MinimalApi/MinimalApi/Program.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.IdentityModel.Tokens;
+using Scalar.AspNetCore;
 
 using MinimalApi.Core;
 using MinimalApi.Data;
@@ -28,8 +29,7 @@ if (OperatingSystem.IsWindows() || OperatingSystem.IsLinux())
 
 // Add services to the container.
 builder.Services.AddControllers();
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+builder.Services.AddOpenApi();
 
 // Add CORS for cross-origin clients
 builder.Services.AddCors(options =>
@@ -125,8 +125,8 @@ app.UseCors("AllowedOrigins");
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
-    app.UseSwagger();
-    app.UseSwaggerUI();
+    app.MapOpenApi();
+    app.MapScalarApiReference();
     app.UseMigrationsEndPoint();
     app.UseDeveloperExceptionPage();
 }

--- a/templates/Aspire/MinimalApi/README.md
+++ b/templates/Aspire/MinimalApi/README.md
@@ -40,7 +40,7 @@ Both options together:
 
 ## What is included
 
-- **API project** – ASP.NET Core Web API with controllers, CORS, Swagger/OpenAPI
+- **API project** – ASP.NET Core Web API with controllers, CORS, OpenAPI, and Scalar API docs (development)
 - **ASP.NET Core Identity** – Cookie + JWT authentication for API endpoints
 - **EF Core** – SQL Server data layer with AppHost-native `AddEFMigrations` orchestration
 - **Aspire AppHost** – Local orchestration with SQL Server container and DB viewer (dbGate)
@@ -59,6 +59,10 @@ Both options together:
 When you run locally, AppHost executes pending EF Core migrations through the `MinimalApi-backend-migrations` resource and starts the backend only after migrations finish.
 
 When you run `aspire publish`, AppHost emits migration artifacts under `efmigrations/` (SQL script + migration bundle).
+
+In development, the API exposes:
+- OpenAPI document: `/openapi/v1.json`
+- Scalar UI: `/scalar`
 
 ### Running tests
 


### PR DESCRIPTION
## Why
The MinimalApi template currently uses Swashbuckle for OpenAPI generation and UI. ASP.NET Core now provides a native OpenAPI pipeline, so this updates the template to the current Microsoft-native approach while keeping interactive docs for local development.

## What changed
- Switched API registration in `Program.cs` from `AddEndpointsApiExplorer`/`AddSwaggerGen` and `UseSwagger*` to `AddOpenApi`, `MapOpenApi`, and `MapScalarApiReference` (development only).
- Replaced `Swashbuckle.AspNetCore` with `Microsoft.AspNetCore.OpenApi` and `Scalar.AspNetCore` in the template project.
- Updated central package versions in `Directory.Packages.props` to include the new packages and remove Swashbuckle.
- Updated template README copy to reflect OpenAPI + Scalar and documented the local docs routes:
  - `/openapi/v1.json`
  - `/scalar`

## Notes
This keeps docs UI exposure in development only, aligned with current guidance to avoid production information disclosure from API docs UIs.