### PR TITLE
feat: Optimize Docker caching for Aspire MinimalApi CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -460,6 +460,7 @@ jobs:
           if (-not (Test-Path $manifestPath)) {
             throw "Aspire manifest smoke check failed: $manifestPath was not created."
           }
+          docker build -f MinimalApi/Dockerfile -t minimalapi-smoke:${{ matrix.variant }} .
 
       - name: Generate merged failure playlist from TRX
         if: always()

--- a/templates/Aspire/MinimalApi/.github/workflows/build-and-deploy.yml
+++ b/templates/Aspire/MinimalApi/.github/workflows/build-and-deploy.yml
@@ -227,8 +227,16 @@ jobs:
     needs: [build, get-infrastructure-outputs]
     if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
     environment: production
+    permissions:
+      id-token: write
+      contents: read
+      actions: write
     steps:
       - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        id: setup-buildx
 
       - name: Azure Login
         uses: azure/login@v3
@@ -241,12 +249,37 @@ jobs:
         run: |
           az acr login --name ${{ needs.get-infrastructure-outputs.outputs.acr_login_server }}
 
-      - name: dotnet publish
-        run: dotnet publish -r linux-x64 --self-contained -t:PublishContainer -p:ContainerRegistry=${{ needs.get-infrastructure-outputs.outputs.acr_login_server }} -p:ContainerImageTags="${{ github.sha }}"
+      - name: Restore BuildKit cache mounts
+        uses: actions/cache@v5
+        id: buildkit-cache
+        with:
+          path: .buildkit-cache
+          key: minimalapi-buildkit-${{ hashFiles('MinimalApi/Dockerfile', 'Directory.Packages.props', 'Directory.Build.props', 'Directory.Build.targets', 'NuGet.config', 'MinimalApi/**/*.csproj') }}
+          restore-keys: |
+            minimalapi-buildkit-
+
+      - name: Inject BuildKit cache mounts
+        uses: reproducible-containers/buildkit-cache-dance@v3
+        with:
+          builder: ${{ steps.setup-buildx.outputs.name }}
+          dockerfile: MinimalApi/Dockerfile
+          cache-dir: .buildkit-cache
+          skip-extraction: ${{ steps.buildkit-cache.outputs.cache-hit == 'true' }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./MinimalApi/Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: ${{ needs.get-infrastructure-outputs.outputs.acr_login_server }}/minimalapi:${{ github.sha }}
+          cache-from: type=gha,scope=minimalapi-main
+          cache-to: type=gha,mode=max,scope=minimalapi-main
 
       - name: Update Container App
         run: |
           az containerapp update `
             --name ${{ needs.get-infrastructure-outputs.outputs.backend_container_app_name }} `
             --resource-group ${{ needs.get-infrastructure-outputs.outputs.resource_group_name }} `
-            --image ${{ needs.get-infrastructure-outputs.outputs.acr_login_server }}/MinimalApi:${{ github.sha }}
+            --image ${{ needs.get-infrastructure-outputs.outputs.acr_login_server }}/minimalapi:${{ github.sha }}

--- a/templates/Aspire/MinimalApi/MinimalApi/.dockerignore
+++ b/templates/Aspire/MinimalApi/MinimalApi/.dockerignore
@@ -23,6 +23,7 @@
 .git/
 .gitattributes
 .gitignore
+.buildkit-cache/
 
 # Docs and CI (not needed in the image)
 .github/

--- a/templates/Aspire/MinimalApi/MinimalApi/Dockerfile
+++ b/templates/Aspire/MinimalApi/MinimalApi/Dockerfile
@@ -14,7 +14,8 @@ COPY ["Directory.Build.props", "."]
 COPY ["Directory.Build.targets", "."]
 COPY ["Directory.Packages.props", "."]
 COPY ["NuGet.config", "."]
-RUN dotnet restore "MinimalApi/MinimalApi.csproj"
+RUN --mount=type=cache,id=minimalapi-nuget,target=/root/.nuget/packages,sharing=locked \
+    dotnet restore "MinimalApi/MinimalApi.csproj"
 
 # Copy remaining source and publish in Release mode
 COPY . .

--- a/templates/Aspire/MinimalApi/MinimalApi/Dockerfile
+++ b/templates/Aspire/MinimalApi/MinimalApi/Dockerfile
@@ -19,7 +19,8 @@ RUN --mount=type=cache,id=minimalapi-nuget,target=/root/.nuget/packages,sharing=
 
 # Copy remaining source and publish in Release mode
 COPY . .
-RUN dotnet publish "MinimalApi/MinimalApi.csproj" \
+RUN --mount=type=cache,id=minimalapi-nuget,target=/root/.nuget/packages,sharing=locked \
+    dotnet publish "MinimalApi/MinimalApi.csproj" \
     -c Release \
     --no-restore \
     -o /app/publish

--- a/templates/Aspire/MinimalApi/MinimalApi/Dockerfile
+++ b/templates/Aspire/MinimalApi/MinimalApi/Dockerfile
@@ -22,7 +22,6 @@ COPY . .
 RUN --mount=type=cache,id=minimalapi-nuget,target=/root/.nuget/packages,sharing=locked \
     dotnet publish "MinimalApi/MinimalApi.csproj" \
     -c Release \
-    --no-restore \
     -o /app/publish
 
 # Runtime stage: Ubuntu Noble Chiseled - distroless-like, minimal attack surface.

--- a/templates/Aspire/MinimalApi/README.md
+++ b/templates/Aspire/MinimalApi/README.md
@@ -119,6 +119,8 @@ docker run -p 8080:8080 \
 ### Aspire vs. standalone Docker
 When running with `aspire run`, the AppHost uses `AddProject<Projects.MinimalApi>` and Aspire handles container publishing automatically (no Dockerfile required). The `Dockerfile` is for non-Aspire workflows only.
 
+The included GitHub Actions workflow uses Docker Buildx with GitHub Actions cache (`cache-from`/`cache-to`) and BuildKit cache-mount persistence for faster repeat builds in CI.
+
 ## Azure deployment
 
 Infrastructure is managed with Terraform under `Infra/`. See `Infra/README.md` for setup instructions.


### PR DESCRIPTION
## Why
Docker caching was underutilized in the Aspire MinimalApi deployment path because backend image builds in CI used `dotnet publish -t:PublishContainer` instead of the repository Dockerfile and Buildx cache features.

## What changed
- Switched the `deploy-backend` workflow job to Docker Buildx (`docker/build-push-action`) using the template Dockerfile and solution-root context.
- Enabled GitHub Actions BuildKit layer cache reuse via `cache-from`/`cache-to` (`type=gha`, `mode=max`, scoped to `minimalapi-main`).
- Added BuildKit cache-mount persistence using `actions/cache` + `reproducible-containers/buildkit-cache-dance`.
- Added a NuGet cache mount to Docker restore for faster repeated package restore during image builds.
- Kept image tags SHA-based and updated deployment image reference to lowercase repository naming (`minimalapi`).
- Documented the CI Docker cache strategy and ignored `.buildkit-cache/` in Docker build context.

## Notes for reviewers
- This change intentionally keeps deploy/push behavior on `main`/manual-dispatch paths as before; it focuses on faster and more deterministic cache behavior for the existing deploy flow.
- The Dockerfile remains compatible with local standalone `docker build -f MinimalApi/Dockerfile ...` usage from the template solution root.