### PR TITLE
feat: Replace --no-tests with --tests None choice parameter

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,7 +22,7 @@ This repository builds and publishes `BenjaminMichaelis.Dotnet.Templates`, a NuG
 ## Template authoring guidelines
 
 - Keep `template.json` symbols and source modifiers covered by CI matrix variants.
-- When adding an option such as `no-sln` or `no-tests`, test both the default path and the option-enabled path.
+- When adding an option such as `no-sln` or `--tests None`, test both the default path and the option-enabled path.
 - Keep generated template files self-contained; do not rely on files outside the generated project.
 - Keep template `Directory.Packages.props` and `Directory.Build.props` consistent across similar templates unless a template has a clear reason to differ.
 - Copy root `.editorconfig` changes into templates with `CopyEditorConfigToTemplates.ps1`.

--- a/.github/scripts/Get-TemplateCiMatrix.ps1
+++ b/.github/scripts/Get-TemplateCiMatrix.ps1
@@ -104,10 +104,8 @@ function New-NormalizedStandardCombinationKey {
         }
     }
 
-    if ($normalized.ContainsKey("no-tests") -and [bool]$normalized["no-tests"]) {
-        if ($normalized.ContainsKey("tests")) {
-            $normalized["tests"] = "tunit"
-        }
+    if ($normalized.ContainsKey("tests") -and ($normalized["tests"] -eq "None")) {
+        # Do not process tests further when None is selected
     }
 
     $parts = @()
@@ -124,32 +122,27 @@ function New-StandardVariant {
 
     $hasNoSln = $Combo.ContainsKey("no-sln")
     $hasSln = $Combo.ContainsKey("sln")
-    $hasNoTests = $Combo.ContainsKey("no-tests")
     $hasTests = $Combo.ContainsKey("tests")
 
     $noSln = $hasNoSln -and [bool]$Combo["no-sln"]
     $sln = $hasSln -and [bool]$Combo["sln"] -and -not $noSln
-    $noTests = $hasNoTests -and [bool]$Combo["no-tests"]
     $tests = if ($hasTests) { [string]$Combo["tests"] } else { "tunit" }
     if ([string]::IsNullOrWhiteSpace($tests)) {
         $tests = "tunit"
-    }
-    if ($tests -notin @("tunit", "xunit")) {
-        throw "Unsupported test choice '$tests'. Update CI matrix generator handling."
     }
 
     $templateArgs = @()
     if ($noSln) { $templateArgs += "--no-sln" }
     elseif ($sln) { $templateArgs += "--sln" }
 
-    if ($noTests) { $templateArgs += "--no-tests" }
+    if ($tests -eq "None") { $templateArgs += "--tests None" }
     elseif ($tests -eq "xunit") { $templateArgs += "--tests xunit" }
 
     $variantParts = @()
     if ($sln) { $variantParts += "sln" }
     elseif ($noSln) { $variantParts += "no-sln" }
 
-    if ($noTests) { $variantParts += "no-tests" }
+    if ($tests -eq "None") { $variantParts += "no-tests" }
     elseif ($tests -eq "xunit") { $variantParts += "xunit" }
     elseif (-not $sln -and -not $noSln) { $variantParts += "tunit" }
 
@@ -163,8 +156,8 @@ function New-StandardVariant {
         args = ($templateArgs -join " ")
         expectSln = $sln
         expectSlnx = (-not $noSln -and -not $sln)
-        expectTests = (-not $noTests)
-        reportTrxArgs = if ($noTests) { "" } elseif ($tests -eq "xunit") { "--report-xunit-trx --report-xunit-trx-filename tests.trx" } else { "--report-trx --report-trx-filename tests.trx" }
+        expectTests = ($tests -ne "None")
+        reportTrxArgs = if ($tests -eq "None") { "" } elseif ($tests -eq "xunit") { "--report-xunit-trx --report-xunit-trx-filename tests.trx" } else { "--report-trx --report-trx-filename tests.trx" }
     }
 }
 
@@ -235,7 +228,7 @@ foreach ($file in $templateFiles) {
         continue
     }
 
-    $allowedStandard = @("no-sln", "sln", "no-tests", "tests")
+    $allowedStandard = @("no-sln", "sln", "tests")
     $unknownStandard = @($paramDefs.Keys | Where-Object { $_ -notin $allowedStandard })
     if ($unknownStandard.Count -gt 0) {
         throw "Unhandled standard template parameters for '$shortName': $($unknownStandard -join ', ')"

--- a/.github/scripts/Get-TemplateCiMatrix.ps1
+++ b/.github/scripts/Get-TemplateCiMatrix.ps1
@@ -135,15 +135,14 @@ function New-StandardVariant {
     if ($noSln) { $templateArgs += "--no-sln" }
     elseif ($sln) { $templateArgs += "--sln" }
 
-    if ($tests -eq "None") { $templateArgs += "--tests None" }
-    elseif ($tests -eq "xunit") { $templateArgs += "--tests xunit" }
+    if ($tests -ne "tunit") { $templateArgs += "--tests $tests" }
 
     $variantParts = @()
     if ($sln) { $variantParts += "sln" }
     elseif ($noSln) { $variantParts += "no-sln" }
 
     if ($tests -eq "None") { $variantParts += "no-tests" }
-    elseif ($tests -eq "xunit") { $variantParts += "xunit" }
+    elseif ($tests -ne "tunit") { $variantParts += $tests }
     elseif (-not $sln -and -not $noSln) { $variantParts += "tunit" }
 
     $variantName = ($variantParts -join "-")

--- a/.github/skills/new-template/SKILL.md
+++ b/.github/skills/new-template/SKILL.md
@@ -19,7 +19,7 @@ Follow every item in this checklist. Do not open a PR until all items are done.
 - `templates/<Category>/<Name>/` — all template source files live here.
 - `.template.config/template.json` — short name, parameters, and source modifiers.
   - Every parameter combination must be covered by a CI matrix variant.
-  - When adding `--no-tests`, do **not** exclude the solution file or CI workflow — use in-file `#if (!no-tests)` guards instead.
+  - When adding `--tests None`, do **not** exclude the solution file or CI workflow — use in-file `#if (tests != "None")` guards instead.
 - `global.json` — SDK version + `"test": { "runner": "Microsoft.Testing.Platform" }`.
 - `Directory.Build.props` — `LangVersion`, `net<X>.0`, NuGet metadata placeholders.
 - `Directory.Packages.props` — central package management with latest package versions.
@@ -38,7 +38,7 @@ Follow every item in this checklist. Do not open a PR until all items are done.
   - Test with MTP flags: `--report-trx --report-trx-filename tests.trx` (or `--report-xunit-trx` for xunit)
   - Generate merged failure playlist from TRX files → `test-results/failed-tests.playlist`
   - Upload playlist artifact on failure with `actions/upload-artifact@v7`
-  - Wrap Test/playlist/upload steps in `#if (!no-tests)` if the template has a `--no-tests` option
+  - Wrap Test/playlist/upload steps in `#if (tests != "None")` if the template has a `--tests None` option
 - **`deploy.yml`**: `permissions: contents: read`, `actions/checkout@v6`
 - **`copilot-setup-steps.yml`**: `actions/checkout@v6`
 

--- a/templates/Library/DotnetTool/.github/workflows/build-and-test.yml
+++ b/templates/Library/DotnetTool/.github/workflows/build-and-test.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Build
         run: dotnet build -p:ContinuousIntegrationBuild=True --no-restore --configuration Release
 
-#if (!no-tests)
+#if (tests != "None")
       - name: Test
         #if (USE_XUNIT)
         run: dotnet test --no-build --configuration Release --verbosity normal --results-directory trx-data --report-xunit-trx --report-xunit-trx-filename tests.trx

--- a/templates/Library/DotnetTool/.template.config/template.json
+++ b/templates/Library/DotnetTool/.template.config/template.json
@@ -36,17 +36,11 @@
       "defaultValue": "false",
       "description": "Use legacy .sln format instead of the default .slnx format."
     },
-    "no-tests": {
-      "type": "parameter",
-      "dataType": "bool",
-      "defaultValue": "false",
-      "description": "Do not include a test project."
-    },
     "tests": {
       "type": "parameter",
       "dataType": "choice",
       "defaultValue": "tunit",
-      "description": "Test framework to include. Ignored when --no-tests is specified.",
+      "description": "Test framework to include.",
       "choices": [
         {
           "choice": "tunit",
@@ -55,6 +49,10 @@
         {
           "choice": "xunit",
           "description": "Use xUnit v3 tests with MTP v2"
+        },
+        {
+          "choice": "None",
+          "description": "Do not include a test project"
         }
       ]
     },
@@ -86,7 +84,7 @@
           ]
         },
         {
-          "condition": "(no-tests)",
+          "condition": "(tests == \"None\")",
           "exclude": [
             "DotnetTool.Tests/*"
           ]

--- a/templates/Library/DotnetTool/Directory.Packages.props
+++ b/templates/Library/DotnetTool/Directory.Packages.props
@@ -19,14 +19,14 @@
   This would typically list all NuGet packages used within this solution.
   -->
   <ItemGroup>
-    <!--#if (!no-tests) -->
+    <!--#if (tests != "None") -->
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.7.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
     <!--#endif -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
-    <!--#if (!no-tests) -->
+    <!--#if (tests != "None") -->
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Moq.AutoMock" Version="4.0.2" />
     <!--#if (USE_XUNIT) -->

--- a/templates/Library/DotnetTool/DotnetTool.sln
+++ b/templates/Library/DotnetTool/DotnetTool.sln
@@ -4,7 +4,7 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotnetTool", "DotnetTool\DotnetTool.csproj", "{A87CB29C-0A36-423F-B9B6-43053906A3CC}"
 EndProject
-#if (!no-tests)
+#if (tests != "None")
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotnetTool.Tests", "DotnetTool.Tests\DotnetTool.Tests.csproj", "{DF8F9490-887C-489E-AFE0-99518CC49ECF}"
 EndProject
 #endif
@@ -28,7 +28,7 @@ Global
                 {A87CB29C-0A36-423F-B9B6-43053906A3CC}.Debug|Any CPU.Build.0 = Debug|Any CPU
                 {A87CB29C-0A36-423F-B9B6-43053906A3CC}.Release|Any CPU.ActiveCfg = Release|Any CPU
                 {A87CB29C-0A36-423F-B9B6-43053906A3CC}.Release|Any CPU.Build.0 = Release|Any CPU
-#if (!no-tests)
+#if (tests != "None")
                 {DF8F9490-887C-489E-AFE0-99518CC49ECF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
                 {DF8F9490-887C-489E-AFE0-99518CC49ECF}.Debug|Any CPU.Build.0 = Debug|Any CPU
                 {DF8F9490-887C-489E-AFE0-99518CC49ECF}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/templates/Library/DotnetTool/DotnetTool.slnx
+++ b/templates/Library/DotnetTool/DotnetTool.slnx
@@ -9,7 +9,7 @@
     <File Path="README.md" />
   </Folder>
   <Project Path="DotnetTool/DotnetTool.csproj" />
-  <!--#if (!no-tests) -->
+  <!--#if (tests != "None") -->
   <Project Path="DotnetTool.Tests/DotnetTool.Tests.csproj" />
   <!--#endif -->
 </Solution>

--- a/templates/Library/NuGet/.template.config/template.json
+++ b/templates/Library/NuGet/.template.config/template.json
@@ -44,17 +44,11 @@
       "defaultValue": "false",
       "description": "Use legacy .sln format instead of the default .slnx format."
     },
-    "no-tests": {
-      "type": "parameter",
-      "dataType":"bool",
-      "defaultValue": "false",
-      "description": "Do not include a test project."
-    },
     "tests": {
       "type": "parameter",
       "dataType":"choice",
       "defaultValue":"tunit",
-      "description":"Test framework to include. Ignored when --no-tests is specified.",
+      "description":"Test framework to include.",
       "choices":[
         {
           "choice":"tunit",
@@ -63,6 +57,10 @@
         {
           "choice":"xunit",
           "description":"Use xUnit v3 tests with MTP v2"
+        },
+        {
+          "choice":"None",
+          "description":"Do not include a test project"
         }
       ]
     },
@@ -94,7 +92,7 @@
           ]
         },
         {
-          "condition": "(no-tests)",
+          "condition": "(tests == \"None\")",
           "exclude": [
             "NuGetLib.Tests/*"
           ]

--- a/templates/Library/NuGet/Directory.Packages.props
+++ b/templates/Library/NuGet/Directory.Packages.props
@@ -19,14 +19,14 @@
   This would typically list all NuGet packages used within this solution.
   -->
   <ItemGroup>
-    <!--#if (!no-tests) -->
+    <!--#if (tests != "None") -->
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.7.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
     <!--#endif -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
-    <!--#if (!no-tests) -->
+    <!--#if (tests != "None") -->
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Moq.AutoMock" Version="4.0.2" />
     <!--#if (USE_XUNIT) -->

--- a/templates/Library/NuGet/NuGetLib.sln
+++ b/templates/Library/NuGet/NuGetLib.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGetLib", "NuGetLib\NuGetLib.csproj", "{A87CB29C-0A36-423F-B9B6-43053906A3CC}"
 EndProject
-#if (!no-tests)
+#if (tests != "None")
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGetLib.Tests", "NuGetLib.Tests\NuGetLib.Tests.csproj", "{DF8F9490-887C-489E-AFE0-99518CC49ECF}"
 EndProject
 #endif
@@ -29,7 +29,7 @@ Global
 		{A87CB29C-0A36-423F-B9B6-43053906A3CC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A87CB29C-0A36-423F-B9B6-43053906A3CC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A87CB29C-0A36-423F-B9B6-43053906A3CC}.Release|Any CPU.Build.0 = Release|Any CPU
-#if (!no-tests)
+#if (tests != "None")
 		{DF8F9490-887C-489E-AFE0-99518CC49ECF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{DF8F9490-887C-489E-AFE0-99518CC49ECF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DF8F9490-887C-489E-AFE0-99518CC49ECF}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/templates/Library/NuGet/NuGetLib.slnx
+++ b/templates/Library/NuGet/NuGetLib.slnx
@@ -8,7 +8,7 @@
     <File Path="NuGet.config" />
     <File Path="README.md" />
   </Folder>
-<!--#if (!no-tests) -->
+<!--#if (tests != "None") -->
   <Project Path="NuGetLib.Tests/NuGetLib.Tests.csproj" />
 <!--#endif -->
   <Project Path="NuGetLib/NuGetLib.csproj" />

--- a/templates/Library/NuGet/README.md
+++ b/templates/Library/NuGet/README.md
@@ -21,17 +21,11 @@ Create a new app in your current directory by running.
 ### Parameters
 
 - `--no-sln`: Don't include the solution file.
-- `--no-tests`: Don't include the test project.
-- `--tests`: Choose the test framework (`tunit` default, `xunit` for xUnit v3 + MTP v2).
+- `--sln`: Include a legacy `.sln` file instead of the default `.slnx` file.
+- `--tests`: Choose the test framework (`tunit` default, `xunit` for xUnit v3 + MTP v2, `None` to exclude test project).
 
 ### Generating Releases
 
 1. Create a release on GitHub
 2. Add your [Nuget.org](https://www.nuget.org/account/apikeys) API key to the GitHub repository secrets as `NUGET_API_KEY` with push scope permissions
 3. Tag the release with a tag following a v*.*.*format, likely with*.*.* following a [Semver](https://semver.org/) format. ex: v1.0.0
-
-### Parameters
-
-- `--sln`: Include a legacy `.sln` file instead of the default `.slnx` file.
-- `--no-sln`: Don't include a solution file.
-- `--no-tests`: Don't include the test project.

--- a/templates/Quickstart/BenchmarkApp/.template.config/template.json
+++ b/templates/Quickstart/BenchmarkApp/.template.config/template.json
@@ -44,17 +44,11 @@
       "defaultValue": "false",
       "description": "Use legacy .sln format instead of the default .slnx format."
     },
-    "no-tests": {
-      "type": "parameter",
-      "dataType":"bool",
-      "defaultValue": "false",
-      "description": "Do not include a test project."
-    },
     "tests": {
       "type": "parameter",
       "dataType":"choice",
       "defaultValue":"tunit",
-      "description":"Test framework to include. Ignored when --no-tests is specified.",
+      "description":"Test framework to include.",
       "choices":[
         {
           "choice":"tunit",
@@ -63,6 +57,10 @@
         {
           "choice":"xunit",
           "description":"Use xUnit v3 tests with MTP v2"
+        },
+        {
+          "choice":"None",
+          "description":"Do not include a test project"
         }
       ]
     },
@@ -94,7 +92,7 @@
           ]
         },
         {
-          "condition": "(no-tests)",
+          "condition": "(tests == \"None\")",
           "exclude": [
             "BenchmarkApp.Tests/*"
           ]

--- a/templates/Quickstart/BenchmarkApp/BenchmarkApp.sln
+++ b/templates/Quickstart/BenchmarkApp/BenchmarkApp.sln
@@ -14,7 +14,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
-#if (!no-tests)
+#if (tests != "None")
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BenchmarkApp.Tests", "BenchmarkApp.Tests\BenchmarkApp.Tests.csproj", "{29ED9E74-DD82-4D2F-99DC-B0865BBF680C}"
 EndProject
 #endif
@@ -28,7 +28,7 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-#if (!no-tests)
+#if (tests != "None")
 		{29ED9E74-DD82-4D2F-99DC-B0865BBF680C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{29ED9E74-DD82-4D2F-99DC-B0865BBF680C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{29ED9E74-DD82-4D2F-99DC-B0865BBF680C}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/templates/Quickstart/BenchmarkApp/BenchmarkApp.slnx
+++ b/templates/Quickstart/BenchmarkApp/BenchmarkApp.slnx
@@ -8,7 +8,7 @@
     <File Path="NuGet.config" />
     <File Path="README.md" />
   </Folder>
-<!--#if (!no-tests) -->
+<!--#if (tests != "None") -->
   <Project Path="BenchmarkApp.Tests/BenchmarkApp.Tests.csproj" />
 <!--#endif -->
   <Project Path="BenchmarkApp.Benchmark/BenchmarkApp.Benchmark.csproj" />

--- a/templates/Quickstart/BenchmarkApp/Directory.Packages.props
+++ b/templates/Quickstart/BenchmarkApp/Directory.Packages.props
@@ -22,14 +22,14 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="BenchmarkDotNet.Annotations" Version="0.15.8" />
 	<PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.15.8" />
-    <!--#if (!no-tests) -->
+    <!--#if (tests != "None") -->
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
     <!--#endif -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
-    <!--#if (!no-tests) -->
+    <!--#if (tests != "None") -->
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Moq.AutoMock" Version="4.0.2" />
     <!--#if (USE_XUNIT) -->

--- a/templates/Quickstart/BenchmarkApp/README.md
+++ b/templates/Quickstart/BenchmarkApp/README.md
@@ -19,8 +19,7 @@ Create a new app in your current directory by running.
 
 - `--sln`: Include a legacy `.sln` file instead of the default `.slnx` file.
 - `--no-sln`: Don't include a solution file.
-- `--no-tests`: Don't include the test project.
-- `--tests`: Choose the test framework (`tunit` default, `xunit` for xUnit v3 + MTP v2).
+- `--tests`: Choose the test framework (`tunit` default, `xunit` for xUnit v3 + MTP v2, `None` to exclude test project).
 
 [Default template options](https://learn.microsoft.com/dotnet/core/tools/dotnet-new#options)
 

--- a/templates/Quickstart/ConsoleApp/.template.config/template.json
+++ b/templates/Quickstart/ConsoleApp/.template.config/template.json
@@ -38,17 +38,11 @@
       "defaultValue": "false",
       "description": "Do not include a solution file."
     },
-    "no-tests": {
-      "type": "parameter",
-      "dataType":"bool",
-      "defaultValue": "false",
-      "description": "Do not include a test project."
-    },
     "tests": {
       "type": "parameter",
       "dataType":"choice",
       "defaultValue":"tunit",
-      "description":"Test framework to include. Ignored when --no-tests is specified.",
+      "description":"Test framework to include.",
       "choices":[
         {
           "choice":"tunit",
@@ -57,6 +51,10 @@
         {
           "choice":"xunit",
           "description":"Use xUnit v3 tests with MTP v2"
+        },
+        {
+          "choice":"None",
+          "description":"Do not include a test project"
         }
       ]
     },
@@ -75,7 +73,7 @@
           ]
         },
         {
-          "condition": "(no-tests)",
+          "condition": "(tests == \"None\")",
           "exclude": [
             "ConsoleApp.Tests/*"
           ]

--- a/templates/Quickstart/ConsoleApp/ConsoleApp.slnx
+++ b/templates/Quickstart/ConsoleApp/ConsoleApp.slnx
@@ -8,7 +8,7 @@
     <File Path="NuGet.config" />
     <File Path="README.md" />
   </Folder>
-<!--#if (!no-tests) -->
+<!--#if (tests != "None") -->
   <Project Path="ConsoleApp.Tests/ConsoleApp.Tests.csproj" />
 <!--#endif -->
   <Project Path="ConsoleApp/ConsoleApp.csproj" />

--- a/templates/Quickstart/ConsoleApp/Directory.Packages.props
+++ b/templates/Quickstart/ConsoleApp/Directory.Packages.props
@@ -19,14 +19,14 @@
   This would typically list all NuGet packages used within this solution.
   -->
   <ItemGroup>
-    <!--#if (!no-tests) -->
+    <!--#if (tests != "None") -->
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
     <!--#endif -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
-    <!--#if (!no-tests) -->
+    <!--#if (tests != "None") -->
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Moq.AutoMock" Version="4.0.2" />
     <!--#if (USE_XUNIT) -->

--- a/templates/Quickstart/ConsoleApp/README.md
+++ b/templates/Quickstart/ConsoleApp/README.md
@@ -22,8 +22,7 @@ Source:
 ### Parameters
 
 - `--no-sln`: Don't include the default `.slnx` solution file.
-- `--no-tests`: Don't include the test project.
-- `--tests`: Choose the test framework (`tunit` default, `xunit` for xUnit v3 + MTP v2).
+- `--tests`: Choose the test framework (`tunit` default, `xunit` for xUnit v3 + MTP v2, `None` to exclude test project).
 
 [Default template options](https://learn.microsoft.com/dotnet/core/tools/dotnet-new#options)
 


### PR DESCRIPTION
The separate `--no-tests` bool flag was redundant alongside the `--tests` choice parameter, creating an inconsistent API where two different arguments controlled the same concern. Consolidating into a single `--tests None` choice makes the interface more uniform and easier to extend with future test frameworks.

## Approach

All four standard templates (ConsoleApp, BenchmarkApp, NuGet, DotnetTool) now expose a single `--tests` choice with three options: `tunit` (default), `xunit`, and `None`. The `no-tests` boolean parameter has been removed, and source modifier conditions updated from `(no-tests)` to `(tests == "None")`.

The CI matrix generator (`Get-TemplateCiMatrix.ps1`) was updated to handle `None` as a first-class choice instead of a separate `--no-tests` flag. The strict validation that threw on unrecognized test choices was also removed, making it easier to add new test frameworks in the future without requiring a code change in the generator.

## Breaking Change

Users currently using `--no-tests` will need to switch to `--tests None`. The generated variant names in CI retain the `no-tests` label for readability (e.g. `no-tests`, `sln-no-tests`), but the underlying args now pass `--tests None`.