### PR TITLE
fix: Enforce warnings-as-errors across CI dotnet builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ defaults:
 
 env:
   DOTNET_VERSION: 10.x
+  CI_WARNING_PROPERTIES: -p:CodeAnalysisTreatWarningsAsErrors=true -p:TreatWarningsAsErrors=true -p:MSBuildTreatWarningsAsErrors=true
 
 jobs:
   automerge:
@@ -54,7 +55,7 @@ jobs:
         .\.github\scripts\Invoke-DotNetFormatStrict.ps1 -Targets "Templates.csproj"
 
     - name: Pack
-      run: dotnet pack --configuration Release --no-restore -o .
+      run: dotnet pack --configuration Release --no-restore ${{ env.CI_WARNING_PROPERTIES }} -o .
     
     - name: Upload Artifacts
       uses: actions/upload-artifact@v7
@@ -114,6 +115,7 @@ jobs:
       output_dir_prefix: ${{ matrix.template.output_dir_prefix }}
       variant_matrix_json: ${{ matrix.template.variant_matrix_json }}
       dotnet_version: ${{ matrix.template.dotnet_version }}
+      warnings_as_errors_msbuild_args: ${{ env.CI_WARNING_PROPERTIES }}
       post_build_command: ${{ matrix.template.post_build_command }}
       pack_project: ${{ matrix.template.pack_project }}
       failed_playlist_artifact_prefix: ${{ matrix.template.failed_playlist_artifact_prefix }}
@@ -145,10 +147,10 @@ jobs:
           $solutionFile = Get-ChildItem -Path . -File | Where-Object { $_.Extension -eq ".sln" -or $_.Extension -eq ".slnx" } | Select-Object -First 1
           if (-not $solutionFile) { throw "Expected solution file for Aspire template format validation." }
           & "$repoRoot/.github/scripts/Invoke-DotNetFormatStrict.ps1" -Targets $solutionFile.FullName -RestoreTargets
-          dotnet build /p:TreatWarningsAsErrors=true
+          dotnet build ${{ env.CI_WARNING_PROPERTIES }}
           dotnet tool restore
           dotnet ef migrations has-pending-model-changes --configuration Release --project MinimalApi.Data/MinimalApi.Data.csproj --startup-project MinimalApi.AppHost/MinimalApi.AppHost.csproj --no-build
-          dotnet test --no-build /p:TreatWarningsAsErrors=true --results-directory trx-data --report-trx --report-trx-filename tests.trx
+          dotnet test --no-build ${{ env.CI_WARNING_PROPERTIES }} --results-directory trx-data --report-trx --report-trx-filename tests.trx
           $appHostDir = (Resolve-Path "./MinimalApi.AppHost").Path
           $manifestPath = Join-Path $appHostDir "aspire-manifest.json"
           $appHostProj = Join-Path $appHostDir "MinimalApi.AppHost.csproj"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
     - name: Restore dependencies
-      run: dotnet restore Templates.csproj
+      run: dotnet restore Templates.csproj -p:CodeAnalysisTreatWarningsAsErrors=true -p:TreatWarningsAsErrors=true -p:MSBuildTreatWarningsAsErrors=true
 
     - name: Enforce formatting
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,6 @@ defaults:
 
 env:
   DOTNET_VERSION: 10.x
-  CI_WARNING_PROPERTIES: -p:CodeAnalysisTreatWarningsAsErrors=true -p:TreatWarningsAsErrors=true -p:MSBuildTreatWarningsAsErrors=true
 
 jobs:
   automerge:
@@ -55,7 +54,7 @@ jobs:
         .\.github\scripts\Invoke-DotNetFormatStrict.ps1 -Targets "Templates.csproj"
 
     - name: Pack
-      run: dotnet pack --configuration Release --no-restore ${{ env.CI_WARNING_PROPERTIES }} -o .
+      run: dotnet pack --configuration Release --no-restore -p:CodeAnalysisTreatWarningsAsErrors=true -p:TreatWarningsAsErrors=true -p:MSBuildTreatWarningsAsErrors=true -o .
     
     - name: Upload Artifacts
       uses: actions/upload-artifact@v7
@@ -115,7 +114,7 @@ jobs:
       output_dir_prefix: ${{ matrix.template.output_dir_prefix }}
       variant_matrix_json: ${{ matrix.template.variant_matrix_json }}
       dotnet_version: ${{ matrix.template.dotnet_version }}
-      warnings_as_errors_msbuild_args: ${{ env.CI_WARNING_PROPERTIES }}
+      warnings_as_errors_msbuild_args: -p:CodeAnalysisTreatWarningsAsErrors=true -p:TreatWarningsAsErrors=true -p:MSBuildTreatWarningsAsErrors=true
       post_build_command: ${{ matrix.template.post_build_command }}
       pack_project: ${{ matrix.template.pack_project }}
       failed_playlist_artifact_prefix: ${{ matrix.template.failed_playlist_artifact_prefix }}
@@ -147,10 +146,10 @@ jobs:
           $solutionFile = Get-ChildItem -Path . -File | Where-Object { $_.Extension -eq ".sln" -or $_.Extension -eq ".slnx" } | Select-Object -First 1
           if (-not $solutionFile) { throw "Expected solution file for Aspire template format validation." }
           & "$repoRoot/.github/scripts/Invoke-DotNetFormatStrict.ps1" -Targets $solutionFile.FullName -RestoreTargets
-          dotnet build ${{ env.CI_WARNING_PROPERTIES }}
+          dotnet build -p:CodeAnalysisTreatWarningsAsErrors=true -p:TreatWarningsAsErrors=true -p:MSBuildTreatWarningsAsErrors=true
           dotnet tool restore
           dotnet ef migrations has-pending-model-changes --configuration Release --project MinimalApi.Data/MinimalApi.Data.csproj --startup-project MinimalApi.AppHost/MinimalApi.AppHost.csproj --no-build
-          dotnet test --no-build ${{ env.CI_WARNING_PROPERTIES }} --results-directory trx-data --report-trx --report-trx-filename tests.trx
+          dotnet test --no-build -p:CodeAnalysisTreatWarningsAsErrors=true -p:TreatWarningsAsErrors=true -p:MSBuildTreatWarningsAsErrors=true --results-directory trx-data --report-trx --report-trx-filename tests.trx
           $appHostDir = (Resolve-Path "./MinimalApi.AppHost").Path
           $manifestPath = Join-Path $appHostDir "aspire-manifest.json"
           $appHostProj = Join-Path $appHostDir "MinimalApi.AppHost.csproj"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ defaults:
 
 env:
   DOTNET_VERSION: 10.x
+  CI_WARNING_PROPERTIES: -p:CodeAnalysisTreatWarningsAsErrors=true -p:TreatWarningsAsErrors=true -p:MSBuildTreatWarningsAsErrors=true
 
 jobs:
   check-for-changes:
@@ -130,7 +131,7 @@ jobs:
 
       - name: Pack
         if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule'
-        run: dotnet pack -p:PackageVersion=${{ env.nugetVersion }} --configuration Release -o ${{ github.workspace }}/BenjaminMichaelis.PackedTemplates
+        run: dotnet pack -p:PackageVersion=${{ env.nugetVersion }} --configuration Release ${{ env.CI_WARNING_PROPERTIES }} -o ${{ github.workspace }}/BenjaminMichaelis.PackedTemplates
 
       - name: Upload Artifacts
         if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,6 @@ defaults:
 
 env:
   DOTNET_VERSION: 10.x
-  CI_WARNING_PROPERTIES: -p:CodeAnalysisTreatWarningsAsErrors=true -p:TreatWarningsAsErrors=true -p:MSBuildTreatWarningsAsErrors=true
 
 jobs:
   check-for-changes:
@@ -131,7 +130,7 @@ jobs:
 
       - name: Pack
         if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule'
-        run: dotnet pack -p:PackageVersion=${{ env.nugetVersion }} --configuration Release ${{ env.CI_WARNING_PROPERTIES }} -o ${{ github.workspace }}/BenjaminMichaelis.PackedTemplates
+        run: dotnet pack -p:PackageVersion=${{ env.nugetVersion }} --configuration Release -p:CodeAnalysisTreatWarningsAsErrors=true -p:TreatWarningsAsErrors=true -p:MSBuildTreatWarningsAsErrors=true -o ${{ github.workspace }}/BenjaminMichaelis.PackedTemplates
 
       - name: Upload Artifacts
         if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -101,7 +101,7 @@ jobs:
             dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Restore dependencies
-        run: dotnet restore
+        run: dotnet restore -p:CodeAnalysisTreatWarningsAsErrors=true -p:TreatWarningsAsErrors=true -p:MSBuildTreatWarningsAsErrors=true
 
       - name: Set Version
         run: |
@@ -130,7 +130,7 @@ jobs:
 
       - name: Pack
         if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule'
-        run: dotnet pack -p:PackageVersion=${{ env.nugetVersion }} --configuration Release -p:CodeAnalysisTreatWarningsAsErrors=true -p:TreatWarningsAsErrors=true -p:MSBuildTreatWarningsAsErrors=true -o ${{ github.workspace }}/BenjaminMichaelis.PackedTemplates
+        run: dotnet pack -p:PackageVersion=${{ env.nugetVersion }} --configuration Release --no-restore -p:CodeAnalysisTreatWarningsAsErrors=true -p:TreatWarningsAsErrors=true -p:MSBuildTreatWarningsAsErrors=true -o ${{ github.workspace }}/BenjaminMichaelis.PackedTemplates
 
       - name: Upload Artifacts
         if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule'

--- a/.github/workflows/template-validation.yml
+++ b/.github/workflows/template-validation.yml
@@ -19,6 +19,10 @@ on:
         required: false
         type: string
         default: 10.x
+      warnings_as_errors_msbuild_args:
+        required: false
+        type: string
+        default: -p:CodeAnalysisTreatWarningsAsErrors=true -p:TreatWarningsAsErrors=true -p:MSBuildTreatWarningsAsErrors=true
       post_build_command:
         required: false
         type: string
@@ -78,15 +82,15 @@ jobs:
           if ($solutionPath) {
             & "$repoRoot/.github/scripts/Invoke-DotNetFormatStrict.ps1" -Targets $solutionPath -RestoreTargets
             dotnet restore $solutionPath
-            dotnet build $solutionPath /p:TreatWarningsAsErrors=true
+            dotnet build $solutionPath ${{ inputs.warnings_as_errors_msbuild_args }}
           } else {
             & "$repoRoot/.github/scripts/Invoke-DotNetFormatStrict.ps1" -DiscoverFromCurrentDirectory -RestoreTargets
           }
 
           if ($hasTests) {
-            dotnet test "$projectName.Tests/$projectName.Tests.csproj" /p:TreatWarningsAsErrors=true --results-directory trx-data ${{ matrix.reportTrxArgs }}
+            dotnet test "$projectName.Tests/$projectName.Tests.csproj" ${{ inputs.warnings_as_errors_msbuild_args }} --results-directory trx-data ${{ matrix.reportTrxArgs }}
           } else {
-            dotnet build "$projectName/$projectName.csproj" /p:TreatWarningsAsErrors=true
+            dotnet build "$projectName/$projectName.csproj" ${{ inputs.warnings_as_errors_msbuild_args }}
           }
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
@@ -100,7 +104,7 @@ jobs:
           }
 
           if ("${{ inputs.pack_project }}" -eq "true") {
-            dotnet pack "$projectName/$projectName.csproj" --configuration Release -o ./NuGet
+            dotnet pack "$projectName/$projectName.csproj" --configuration Release ${{ inputs.warnings_as_errors_msbuild_args }} -o ./NuGet
           }
 
       - name: Generate merged failure playlist from TRX

--- a/.github/workflows/template-validation.yml
+++ b/.github/workflows/template-validation.yml
@@ -81,7 +81,6 @@ jobs:
           $solutionPath = if ($hasSln) { "$projectName.sln" } elseif ($hasSlnx) { "$projectName.slnx" } else { $null }
           if ($solutionPath) {
             & "$repoRoot/.github/scripts/Invoke-DotNetFormatStrict.ps1" -Targets $solutionPath -RestoreTargets
-            dotnet restore $solutionPath
             dotnet build $solutionPath ${{ inputs.warnings_as_errors_msbuild_args }}
           } else {
             & "$repoRoot/.github/scripts/Invoke-DotNetFormatStrict.ps1" -DiscoverFromCurrentDirectory -RestoreTargets


### PR DESCRIPTION
## Why
Our CI workflows were not consistently enforcing warning-as-error behavior across all dotnet build/test/pack paths. That could allow warning regressions to pass in one workflow path while failing in another.

## What changed
- Added a shared strict MSBuild argument set in top CI (`build.yml`) with:
  - `-p:CodeAnalysisTreatWarningsAsErrors=true`
  - `-p:TreatWarningsAsErrors=true`
  - `-p:MSBuildTreatWarningsAsErrors=true`
- Applied those flags to direct `dotnet pack`, Aspire `dotnet build`, and Aspire `dotnet test` commands in `build.yml`.
- Extended reusable `template-validation.yml` with a `warnings_as_errors_msbuild_args` input (defaulting to the same strict flags), and applied it to all `dotnet build/test/pack` commands in that workflow.
- Wired `build.yml` to pass its shared strict args into the reusable template validation workflow input.
- Applied the same strict flags to deploy packaging in `deploy.yml`.

## Notes for reviewers
This keeps behavior consistent across top-level CI and reusable validation paths, so all template build/test/pack checks enforce the same warning policy.