### PR TITLE
feat: Use global.json for .NET SDK setup in workflows

### DIFF
--- a/.github/actions/setup-template-test/action.yml
+++ b/.github/actions/setup-template-test/action.yml
@@ -2,9 +2,6 @@ name: Setup template test environment
 description: Checkout, download template package artifact, setup .NET, restore tools, and install template pack.
 
 inputs:
-  dotnet-version:
-    description: .NET SDK version to install
-    required: true
   artifact-name:
     description: Build artifact name containing template nupkg
     required: false
@@ -26,7 +23,7 @@ runs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: ${{ inputs.dotnet-version }}
+        global-json-file: ./global.json
 
     - name: Restore .NET Tools
       shell: pwsh

--- a/.github/scripts/Get-TemplateCiMatrix.ps1
+++ b/.github/scripts/Get-TemplateCiMatrix.ps1
@@ -294,7 +294,6 @@ foreach ($file in $templateFiles) {
             project_name = $projectName
             output_dir_prefix = $outputDirPrefix
             variant_matrix_json = (Get-CompactJson -Value @{ include = $variants })
-            dotnet_version = "10.x"
             post_build_command = $postBuildCommand
             pack_project = $packProject
             failed_playlist_artifact_prefix = "failed-tests-playlist-$artifactSuffix"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,6 @@ defaults:
   run:
     shell: pwsh
 
-env:
-  DOTNET_VERSION: 10.x
-
 jobs:
   automerge:
     runs-on: ubuntu-latest
@@ -44,7 +41,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: ${{ env.DOTNET_VERSION }}
+        global-json-file: ./global.json
 
     - name: Restore dependencies
       run: dotnet restore Templates.csproj
@@ -113,7 +110,6 @@ jobs:
       project_name: ${{ matrix.template.project_name }}
       output_dir_prefix: ${{ matrix.template.output_dir_prefix }}
       variant_matrix_json: ${{ matrix.template.variant_matrix_json }}
-      dotnet_version: ${{ matrix.template.dotnet_version }}
       post_build_command: ${{ matrix.template.post_build_command }}
       pack_project: ${{ matrix.template.pack_project }}
       failed_playlist_artifact_prefix: ${{ matrix.template.failed_playlist_artifact_prefix }}
@@ -131,8 +127,6 @@ jobs:
 
       - name: Setup test environment
         uses: ./.github/actions/setup-template-test
-        with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Test Template (${{ matrix.variant }})
         run: |

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -17,9 +17,6 @@ defaults:
   run:
     shell: pwsh
 
-env:
-  DOTNET_VERSION: 9.x
-
 jobs:
   copilot-setup-steps:
     name: copilot-setup-steps
@@ -33,7 +30,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: ${{ env.DOTNET_VERSION }}
+        global-json-file: ./global.json
     - name: Setup Dependency Caching
       uses: actions/cache@v5
       id: nuget-cache

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,9 +14,6 @@ defaults:
   run:
     shell: pwsh
 
-env:
-  DOTNET_VERSION: 10.x
-
 jobs:
   check-for-changes:
     runs-on: ubuntu-latest
@@ -98,7 +95,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-            dotnet-version: ${{ env.DOTNET_VERSION }}
+            global-json-file: ./global.json
 
       - name: Restore dependencies
         run: dotnet restore

--- a/.github/workflows/template-validation.yml
+++ b/.github/workflows/template-validation.yml
@@ -15,10 +15,6 @@ on:
       variant_matrix_json:
         required: true
         type: string
-      dotnet_version:
-        required: false
-        type: string
-        default: 10.x
       post_build_command:
         required: false
         type: string
@@ -51,8 +47,6 @@ jobs:
 
       - name: Setup test environment
         uses: ./.github/actions/setup-template-test
-        with:
-          dotnet-version: ${{ inputs.dotnet_version }}
 
       - name: Validate template (${{ matrix.variant }})
         env:


### PR DESCRIPTION
## Why
Our CI had hardcoded `dotnet-version` values in multiple workflow paths, which can drift from the SDK version the repo actually targets. This change aligns CI SDK resolution with the repo's pinned SDK configuration.

## What changed
- Switched `actions/setup-dotnet` to `global-json-file: ./global.json` in:
  - `build.yml`
  - `deploy.yml`
  - `copilot-setup-steps.yml`
  - `.github/actions/setup-template-test/action.yml`
- Removed now-unused `dotnet_version` plumbing from:
  - `.github/workflows/template-validation.yml`
  - `.github/scripts/Get-TemplateCiMatrix.ps1`

## Notes
- The existing `test.runner` declaration for Microsoft.Testing.Platform remains in `global.json` files and is unchanged.
- No functional template behavior changed; this is CI SDK source-of-truth cleanup.