### PR TITLE
fix: Use manifest-pinned dotnet-ef for pending model checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,7 +147,7 @@ jobs:
           & "$repoRoot/.github/scripts/Invoke-DotNetFormatStrict.ps1" -Targets $solutionFile.FullName -RestoreTargets
           dotnet build /p:TreatWarningsAsErrors=true
           dotnet tool restore
-          dotnet ef migrations has-pending-model-changes --configuration Release --project MinimalApi.Data/MinimalApi.Data.csproj --startup-project MinimalApi.AppHost/MinimalApi.AppHost.csproj --no-build
+          dotnet tool run dotnet-ef migrations has-pending-model-changes --configuration Release --project MinimalApi.Data/MinimalApi.Data.csproj --startup-project MinimalApi.AppHost/MinimalApi.AppHost.csproj --no-build
           dotnet test --no-build /p:TreatWarningsAsErrors=true --results-directory trx-data --report-trx --report-trx-filename tests.trx
           $appHostDir = (Resolve-Path "./MinimalApi.AppHost").Path
           $manifestPath = Join-Path $appHostDir "aspire-manifest.json"

--- a/templates/Aspire/MinimalApi/.github/workflows/build-and-deploy.yml
+++ b/templates/Aspire/MinimalApi/.github/workflows/build-and-deploy.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Check for Pending Database Changes
         run: |
-          dotnet ef migrations has-pending-model-changes `
+          dotnet tool run dotnet-ef migrations has-pending-model-changes `
             --configuration Release `
             --project MinimalApi.Data/MinimalApi.Data.csproj `
            --startup-project MinimalApi.AppHost/MinimalApi.AppHost.csproj

--- a/templates/Aspire/MinimalApi/.github/workflows/build-and-deploy.yml
+++ b/templates/Aspire/MinimalApi/.github/workflows/build-and-deploy.yml
@@ -55,7 +55,8 @@ jobs:
           dotnet tool run dotnet-ef migrations has-pending-model-changes `
             --configuration Release `
             --project MinimalApi.Data/MinimalApi.Data.csproj `
-           --startup-project MinimalApi.AppHost/MinimalApi.AppHost.csproj
+            --startup-project MinimalApi.AppHost/MinimalApi.AppHost.csproj `
+            --no-build
 
       # Microsoft Testing Platform can stop the run once 10 tests fail in CI:
       # https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-cli-options


### PR DESCRIPTION
## Summary
CI was invoking `dotnet ef` directly for pending-model-change checks, which can pick up a global tool version instead of the repo-declared one. This updates those checks to run through the restored local tool manifest.

## What changed
- Replaced `dotnet ef migrations has-pending-model-changes` with `dotnet tool run dotnet-ef migrations has-pending-model-changes` in:
  - `.github/workflows/build.yml`
  - `templates/Aspire/MinimalApi/.github/workflows/build-and-deploy.yml`

## Notes
- `dotnet tool restore` already runs before these commands, so the EF CLI version now consistently comes from `.config/dotnet-tools.json` in each respective repo/template context.