### PR TITLE
ci: export runtime vars before dotnet test in template workflows

### DIFF
--- a/templates/Aspire/MinimalApi/.github/workflows/build-and-deploy.yml
+++ b/templates/Aspire/MinimalApi/.github/workflows/build-and-deploy.yml
@@ -63,6 +63,13 @@ jobs:
       # To enable retries, add Microsoft.Testing.Extensions.Retry to the test project, then pass
       # --retry-failed-tests plus --retry-failed-tests-max-percentage <value> to skip reruns when too many tests fail:
       # https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-retry#retry-1
+      - name: Enable Automated Test Report Artifact Upload
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env['ACTIONS_RUNTIME_TOKEN']);
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env['ACTIONS_RESULTS_URL']);
+
       - name: Test
         run: dotnet test --no-build --configuration Release --verbosity normal --maximum-failed-tests 10 --results-directory trx-data --report-trx --report-trx-filename tests.trx
 

--- a/templates/Library/DotnetTool/.github/workflows/build-and-test.yml
+++ b/templates/Library/DotnetTool/.github/workflows/build-and-test.yml
@@ -60,6 +60,13 @@ jobs:
         run: dotnet build -p:ContinuousIntegrationBuild=True --no-restore --configuration Release
 
 #if (tests != "None")
+      - name: Enable Automated Test Report Artifact Upload
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env['ACTIONS_RUNTIME_TOKEN']);
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env['ACTIONS_RESULTS_URL']);
+
       - name: Test
         #if (USE_XUNIT)
         run: dotnet test --no-build --configuration Release --verbosity normal --results-directory trx-data --report-xunit-trx --report-xunit-trx-filename tests.trx

--- a/templates/Library/NuGet/.github/workflows/build-and-test.yml
+++ b/templates/Library/NuGet/.github/workflows/build-and-test.yml
@@ -60,6 +60,13 @@ jobs:
       - name: Build
         run: dotnet build -p:ContinuousIntegrationBuild=True --no-restore --configuration Release
   
+      - name: Enable Automated Test Report Artifact Upload
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env['ACTIONS_RUNTIME_TOKEN']);
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env['ACTIONS_RESULTS_URL']);
+
       - name: Test
         #if (USE_XUNIT)
         run: dotnet test --no-build --configuration Release --verbosity normal --results-directory trx-data --report-xunit-trx --report-xunit-trx-filename tests.trx

--- a/templates/Quickstart/BenchmarkApp/.github/workflows/build-and-test.yml
+++ b/templates/Quickstart/BenchmarkApp/.github/workflows/build-and-test.yml
@@ -60,6 +60,13 @@ jobs:
       - name: Build
         run: dotnet build -p:ContinuousIntegrationBuild=True --no-restore --configuration Release
   
+      - name: Enable Automated Test Report Artifact Upload
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env['ACTIONS_RUNTIME_TOKEN']);
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env['ACTIONS_RESULTS_URL']);
+
       - name: Test
         #if (USE_XUNIT)
         run: dotnet test --no-build --configuration Release --verbosity normal --results-directory trx-data --report-xunit-trx --report-xunit-trx-filename tests.trx

--- a/templates/Quickstart/ConsoleApp/.github/workflows/build-and-test.yml
+++ b/templates/Quickstart/ConsoleApp/.github/workflows/build-and-test.yml
@@ -60,6 +60,13 @@ jobs:
       - name: Build
         run: dotnet build -p:ContinuousIntegrationBuild=True --no-restore --configuration Release
   
+      - name: Enable Automated Test Report Artifact Upload
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env['ACTIONS_RUNTIME_TOKEN']);
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env['ACTIONS_RESULTS_URL']);
+
       - name: Test
         #if (USE_XUNIT)
         run: dotnet test --no-build --configuration Release --verbosity normal --results-directory trx-data --report-xunit-trx --report-xunit-trx-filename tests.trx


### PR DESCRIPTION
## Why
GitHub Actions does not expose `ACTIONS_RUNTIME_TOKEN` to shell `run:` steps by default. Without explicitly exporting it (and `ACTIONS_RESULTS_URL`) before tests run, automatic test report artifact upload cannot work reliably in generated template workflows.

## What changed
This updates each template workflow that runs `dotnet test` to add a pre-test `actions/github-script@v7` step named `Enable Automated Test Report Artifact Upload` that exports:
- `ACTIONS_RUNTIME_TOKEN`
- `ACTIONS_RESULTS_URL`

## Scope
Applied to the template workflow files for:
- Quickstart ConsoleApp
- Quickstart BenchmarkApp
- Library NuGet
- Library DotnetTool
- Aspire MinimalApi