### PR TITLE
chore: Convert to C# 14 extension block syntax

### DIFF
--- a/templates/Aspire/MinimalApi/MinimalApi.Core.Tests/AutoMockerExtensions.Database.cs
+++ b/templates/Aspire/MinimalApi/MinimalApi.Core.Tests/AutoMockerExtensions.Database.cs
@@ -9,7 +9,7 @@ using Moq.AutoMock.Resolvers;
 
 namespace MinimalApi.Core.Tests;
 
-public static partial class AutoMockerExtensions
+public static class AutoMockerExtensions
 {
     extension(AutoMocker mocker)
     {

--- a/templates/Aspire/MinimalApi/MinimalApi.Core/DependencyInjection.cs
+++ b/templates/Aspire/MinimalApi/MinimalApi.Core/DependencyInjection.cs
@@ -11,41 +11,43 @@ namespace MinimalApi.Core;
 
 public static class DependencyInjection
 {
-    public static TBuilder AddDatabase<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    extension<TBuilder>(TBuilder builder) where TBuilder : IHostApplicationBuilder
     {
-        var connectionString = builder.Configuration.GetConnectionString(ConnectionStrings.DatabaseKey)
-            ?? throw new InvalidOperationException($"Connection string '{ConnectionStrings.DatabaseKey}' not found.");
-
-        void BuildDbOptions(DbContextOptionsBuilder options)
+        public TBuilder AddDatabase()
         {
-            options.UseAzureSql(connectionString);
+            var connectionString = builder.Configuration.GetConnectionString(ConnectionStrings.DatabaseKey)
+                ?? throw new InvalidOperationException($"Connection string '{ConnectionStrings.DatabaseKey}' not found.");
+
+            void BuildDbOptions(DbContextOptionsBuilder options)
+            {
+                options.UseAzureSql(connectionString);
+            }
+            builder.Services.AddDbContextFactory<ApplicationDbContext>(BuildDbOptions);
+            builder.Services.AddDbContextPool<ApplicationDbContext>(BuildDbOptions);
+
+            if (builder.Environment.IsDevelopment())
+            {
+                builder.Services.AddDatabaseDeveloperPageExceptionFilter();
+            }
+
+            builder.Services.AddIdentityCore<ApplicationUser>(options =>
+            {
+                options.SignIn.RequireConfirmedAccount = true;
+                options.Stores.SchemaVersion = IdentitySchemaVersions.Version3;
+            })
+            .AddEntityFrameworkStores<ApplicationDbContext>()
+            .AddSignInManager()
+            .AddDefaultTokenProviders();
+
+            return builder;
         }
-        builder.Services.AddDbContextFactory<ApplicationDbContext>(BuildDbOptions);
-        builder.Services.AddDbContextPool<ApplicationDbContext>(BuildDbOptions);
 
-        if (builder.Environment.IsDevelopment())
+        public TBuilder AddQAServices()
         {
-            builder.Services.AddDatabaseDeveloperPageExceptionFilter();
+            builder.Services.AddScoped<IRoomService, RoomService>();
+            builder.Services.AddScoped<IQuestionService, QuestionService>();
+
+            return builder;
         }
-
-        builder.Services.AddIdentityCore<ApplicationUser>(options =>
-        {
-            options.SignIn.RequireConfirmedAccount = true;
-            options.Stores.SchemaVersion = IdentitySchemaVersions.Version3;
-        })
-        .AddEntityFrameworkStores<ApplicationDbContext>()
-        .AddSignInManager()
-        .AddDefaultTokenProviders();
-
-        return builder;
     }
-
-    public static TBuilder AddQAServices<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
-    {
-        builder.Services.AddScoped<IRoomService, RoomService>();
-        builder.Services.AddScoped<IQuestionService, QuestionService>();
-
-        return builder;
-    }
-
 }

--- a/templates/Aspire/MinimalApi/MinimalApi.ServiceDefaults/Extensions.cs
+++ b/templates/Aspire/MinimalApi/MinimalApi.ServiceDefaults/Extensions.cs
@@ -21,108 +21,114 @@ public static class Extensions
     private const string HealthEndpointPath = "/health";
     private const string AlivenessEndpointPath = "/alive";
 
-    public static TBuilder AddServiceDefaults<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    extension<TBuilder>(TBuilder builder) where TBuilder : IHostApplicationBuilder
     {
-        builder.ConfigureOpenTelemetry();
-
-        builder.AddDefaultHealthChecks();
-
-        builder.Services.AddServiceDiscovery();
-
-        builder.Services.ConfigureHttpClientDefaults(http =>
+        public TBuilder AddServiceDefaults()
         {
-            // Turn on resilience by default
-            http.AddStandardResilienceHandler();
+            builder.ConfigureOpenTelemetry();
 
-            // Turn on service discovery by default
-            http.AddServiceDiscovery();
-        });
+            builder.AddDefaultHealthChecks();
 
-        // Uncomment the following to restrict the allowed schemes for service discovery.
-        // builder.Services.Configure<ServiceDiscoveryOptions>(options =>
-        // {
-        //     options.AllowedSchemes = ["https"];
-        // });
+            builder.Services.AddServiceDiscovery();
 
-        return builder;
-    }
-
-    public static TBuilder ConfigureOpenTelemetry<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
-    {
-        builder.Logging.AddOpenTelemetry(logging =>
-        {
-            logging.IncludeFormattedMessage = true;
-            logging.IncludeScopes = true;
-        });
-
-        builder.Services.AddOpenTelemetry()
-            .WithMetrics(metrics =>
+            builder.Services.ConfigureHttpClientDefaults(http =>
             {
-                metrics.AddAspNetCoreInstrumentation()
-                    .AddHttpClientInstrumentation()
-                    .AddRuntimeInstrumentation();
-            })
-            .WithTracing(tracing =>
-            {
-                tracing.AddSource(builder.Environment.ApplicationName)
-                    .AddAspNetCoreInstrumentation(tracing =>
-                        // Exclude health check requests from tracing
-                        tracing.Filter = context =>
-                            !context.Request.Path.StartsWithSegments(HealthEndpointPath)
-                            && !context.Request.Path.StartsWithSegments(AlivenessEndpointPath)
-                    )
-                    // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
-                    //.AddGrpcClientInstrumentation()
-                    .AddHttpClientInstrumentation();
+                // Turn on resilience by default
+                http.AddStandardResilienceHandler();
+
+                // Turn on service discovery by default
+                http.AddServiceDiscovery();
             });
 
-        builder.AddOpenTelemetryExporters();
+            // Uncomment the following to restrict the allowed schemes for service discovery.
+            // builder.Services.Configure<ServiceDiscoveryOptions>(options =>
+            // {
+            //     options.AllowedSchemes = ["https"];
+            // });
 
-        return builder;
-    }
-
-    private static TBuilder AddOpenTelemetryExporters<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
-    {
-        var useOtlpExporter = !string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
-
-        if (useOtlpExporter)
-        {
-            builder.Services.AddOpenTelemetry().UseOtlpExporter();
+            return builder;
         }
 
-        // Uncomment the following lines to enable the Azure Monitor exporter (requires the Azure.Monitor.OpenTelemetry.AspNetCore package)
-        if (!string.IsNullOrEmpty(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
+        public TBuilder ConfigureOpenTelemetry()
         {
+            builder.Logging.AddOpenTelemetry(logging =>
+            {
+                logging.IncludeFormattedMessage = true;
+                logging.IncludeScopes = true;
+            });
+
             builder.Services.AddOpenTelemetry()
-               .UseAzureMonitor();
+                .WithMetrics(metrics =>
+                {
+                    metrics.AddAspNetCoreInstrumentation()
+                        .AddHttpClientInstrumentation()
+                        .AddRuntimeInstrumentation();
+                })
+                .WithTracing(tracing =>
+                {
+                    tracing.AddSource(builder.Environment.ApplicationName)
+                        .AddAspNetCoreInstrumentation(tracing =>
+                            // Exclude health check requests from tracing
+                            tracing.Filter = context =>
+                                !context.Request.Path.StartsWithSegments(HealthEndpointPath)
+                                && !context.Request.Path.StartsWithSegments(AlivenessEndpointPath)
+                        )
+                        // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
+                        //.AddGrpcClientInstrumentation()
+                        .AddHttpClientInstrumentation();
+                });
+
+            builder.AddOpenTelemetryExporters();
+
+            return builder;
         }
 
-        return builder;
-    }
-
-    public static TBuilder AddDefaultHealthChecks<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
-    {
-        builder.Services.AddHealthChecks()
-            // Add a default liveness check to ensure app is responsive
-            .AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
-
-        return builder;
-    }
-
-    public static WebApplication MapDefaultEndpoints(this WebApplication app)
-    {
-        // Adding health checks endpoints to applications in non-development environments has security implications.
-        // See https://aka.ms/dotnet/aspire/healthchecks for details.
-
-        // All health checks must pass for app to be considered ready to accept traffic after starting
-        app.MapHealthChecks(HealthEndpointPath);
-
-        // Only health checks tagged with the "live" tag must pass for app to be considered alive
-        app.MapHealthChecks(AlivenessEndpointPath, new HealthCheckOptions
+        private TBuilder AddOpenTelemetryExporters()
         {
-            Predicate = r => r.Tags.Contains("live")
-        });
+            var useOtlpExporter = !string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
 
-        return app;
+            if (useOtlpExporter)
+            {
+                builder.Services.AddOpenTelemetry().UseOtlpExporter();
+            }
+
+            // Uncomment the following lines to enable the Azure Monitor exporter (requires the Azure.Monitor.OpenTelemetry.AspNetCore package)
+            if (!string.IsNullOrEmpty(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
+            {
+                builder.Services.AddOpenTelemetry()
+                   .UseAzureMonitor();
+            }
+
+            return builder;
+        }
+
+        public TBuilder AddDefaultHealthChecks()
+        {
+            builder.Services.AddHealthChecks()
+                // Add a default liveness check to ensure app is responsive
+                .AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
+
+            return builder;
+        }
+    }
+
+    extension(WebApplication app)
+    {
+        public WebApplication MapDefaultEndpoints()
+        {
+            // Adding health checks endpoints to applications in non-development environments has security implications.
+            // See https://aka.ms/dotnet/aspire/healthchecks for details.
+
+            // All health checks must pass for app to be considered ready to accept traffic after starting
+            app.MapHealthChecks(HealthEndpointPath);
+
+            // Only health checks tagged with the "live" tag must pass for app to be considered alive
+            app.MapHealthChecks(AlivenessEndpointPath, new HealthCheckOptions
+            {
+                Predicate = r => r.Tags.Contains("live")
+            });
+
+            return app;
+        }
     }
 }


### PR DESCRIPTION
## Summary

Standardizes all extension methods across templates to use modern C# 14 extension block syntax, providing cleaner code that aligns with .NET 10 capabilities.

## Changes

- **ServiceDefaults/Extensions.cs**: Convert 5 extension methods to use `extension<TBuilder>()` and `extension(WebApplication)` blocks
- **Core/DependencyInjection.cs**: Convert 2 extension methods to use `extension<TBuilder>()` block
- **AutoMockerExtensions.Database.cs**: Remove unnecessary `partial` keyword (single-file class)

## Why

C# 14 extension blocks eliminate the `this` parameter requirement and reduce boilerplate, making extension methods more concise and improving IDE support. This change maintains full backward compatibility while modernizing the codebase.

## Validation

- All MinimalApi template projects build successfully
- No functional changes; pure syntax modernization
- Consistent with existing patterns in AspireExtensions.cs and AutoMockerExtensions.Database.cs