### PR TITLE
feat(aspire-template): adopt improvements from upstream aspire-starter template

### DIFF
--- a/templates/Aspire/MinimalApi/Directory.Packages.props
+++ b/templates/Aspire/MinimalApi/Directory.Packages.props
@@ -35,7 +35,9 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageVersion Include="Polly.Core" Version="8.6.6" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.14.14" />
+    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
     <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.7.2" />
+    <PackageVersion Include="MessagePack" Version="2.5.302" />
   </ItemGroup>
 </Project>

--- a/templates/Aspire/MinimalApi/MinimalApi/Middleware/ExceptionHandlingMiddleware.cs
+++ b/templates/Aspire/MinimalApi/MinimalApi/Middleware/ExceptionHandlingMiddleware.cs
@@ -1,12 +1,13 @@
-using System.Net;
-using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
 
 namespace MinimalApi.Middleware;
 
 /// <summary>
-/// Middleware to handle exceptions and return appropriate HTTP status codes
+/// Middleware to map well-known exception types to specific HTTP status codes.
+/// Writes RFC 9457 ProblemDetails responses via IProblemDetailsService so the
+/// error shape is consistent with UseExceptionHandler() for all other errors.
 /// </summary>
-public class ExceptionHandlingMiddleware(RequestDelegate next, ILogger<ExceptionHandlingMiddleware> logger)
+public class ExceptionHandlingMiddleware(RequestDelegate next, ILogger<ExceptionHandlingMiddleware> logger, IProblemDetailsService problemDetailsService)
 {
     public async Task InvokeAsync(HttpContext context)
     {
@@ -17,27 +18,27 @@ public class ExceptionHandlingMiddleware(RequestDelegate next, ILogger<Exception
         catch (UnauthorizedAccessException ex)
         {
             logger.LogWarning(ex, "Unauthorized access attempt: {Message}", ex.Message);
-            await HandleExceptionAsync(context, ex, HttpStatusCode.Forbidden);
+            await WriteProblemDetailsAsync(context, ex, StatusCodes.Status403Forbidden);
         }
         catch (InvalidOperationException ex)
         {
             logger.LogWarning(ex, "Invalid operation: {Message}", ex.Message);
-            await HandleExceptionAsync(context, ex, HttpStatusCode.BadRequest);
+            await WriteProblemDetailsAsync(context, ex, StatusCodes.Status400BadRequest);
         }
     }
 
-    private static async Task HandleExceptionAsync(HttpContext context, Exception exception, HttpStatusCode statusCode)
+    private async Task WriteProblemDetailsAsync(HttpContext context, Exception exception, int statusCode)
     {
-        context.Response.ContentType = "application/json";
-        context.Response.StatusCode = (int)statusCode;
-
-        var response = new
+        context.Response.StatusCode = statusCode;
+        await problemDetailsService.WriteAsync(new ProblemDetailsContext
         {
-            statusCode = (int)statusCode,
-            message = exception.Message
-        };
-
-        var json = JsonSerializer.Serialize(response);
-        await context.Response.WriteAsync(json);
+            HttpContext = context,
+            Exception = exception,
+            ProblemDetails = new ProblemDetails
+            {
+                Status = statusCode,
+                Detail = exception.Message,
+            },
+        });
     }
 }

--- a/templates/Aspire/MinimalApi/MinimalApi/Program.cs
+++ b/templates/Aspire/MinimalApi/MinimalApi/Program.cs
@@ -30,6 +30,7 @@ if (OperatingSystem.IsWindows() || OperatingSystem.IsLinux())
 
 // Add services to the container.
 builder.Services.AddControllers();
+builder.Services.AddProblemDetails();
 builder.Services.AddOpenApi();
 
 // Add CORS for cross-origin clients
@@ -120,20 +121,20 @@ var app = builder.Build();
 
 app.MapDefaultEndpoints();
 
+// Configure the HTTP request pipeline.
+app.UseExceptionHandler();
+
 // Enable CORS
 app.UseCors("AllowedOrigins");
 
-// Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();
     app.MapScalarApiReference();
     app.UseMigrationsEndPoint();
-    app.UseDeveloperExceptionPage();
 }
 else
 {
-    app.UseExceptionHandler("/Error");
     app.UseHsts();
     app.UseHttpsRedirection();
 }
@@ -143,6 +144,8 @@ app.UseMiddleware<ExceptionHandlingMiddleware>();
 
 app.UseAuthentication();
 app.UseAuthorization();
+
+app.MapGet("/", () => "API is running.");
 
 app.MapControllers();
 

--- a/templates/Aspire/MinimalApi/MinimalApi/Properties/launchSettings.json
+++ b/templates/Aspire/MinimalApi/MinimalApi/Properties/launchSettings.json
@@ -1,6 +1,15 @@
 {
   "$schema": "https://json.schemastore.org/launchsettings.json",
     "profiles": {
+      "http": {
+        "commandName": "Project",
+        "dotnetRunMessages": true,
+        "launchBrowser": false,
+        "applicationUrl": "http://localhost:5285",
+        "environmentVariables": {
+          "ASPNETCORE_ENVIRONMENT": "Development"
+        }
+      },
       "https": {
         "commandName": "Project",
         "dotnetRunMessages": true,

--- a/templates/Aspire/MinimalApi/MinimalApi/appsettings.json
+++ b/templates/Aspire/MinimalApi/MinimalApi/appsettings.json
@@ -2,7 +2,7 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Information"
+      "Microsoft.AspNetCore": "Warning"
     },
     "Console": {
       "FormatterName": "simple",


### PR DESCRIPTION
Reviewing the official `aspire-starter` ApiService template revealed a few patterns we were missing or doing incorrectly. This PR adapts the useful ones.

## What changed and why

**`AddProblemDetails()` + `UseExceptionHandler()` (no path)**

The old code called `app.UseExceptionHandler("/Error")` in production, but `/Error` was never registered -- so any unhandled exception that slipped past `ExceptionHandlingMiddleware` would produce a 404 redirect loop instead of an error response. The fix is to add `builder.Services.AddProblemDetails()` and use the no-arg `UseExceptionHandler()` overload, which ASP.NET Core automatically wires to return RFC 9457 ProblemDetails JSON without needing a dedicated error route. `UseExceptionHandler()` is also moved to the top of the pipeline (before CORS) which is the correct placement.

**`UseDeveloperExceptionPage()` removed**

With `UseExceptionHandler()` covering both dev and prod environments, the explicit `UseDeveloperExceptionPage()` call is redundant and was removed.

**Root `GET /` endpoint**

The API previously returned 404 at the root URL. A minimal `app.MapGet("/", ...)` endpoint gives a quick smoke-test signal that the service is up, matching the upstream pattern.

**`Microsoft.AspNetCore` log level in `appsettings.json`**

The base settings file (used in production) had `"Microsoft.AspNetCore": "Information"`, which produces a lot of framework noise in prod. Changed to `"Warning"`. The `appsettings.Development.json` already has `"Information"` so dev behavior is unchanged.

**`http` launch profile added**

The `launchSettings.json` previously only had an `https` profile. Added an `http` profile alongside it so developers running in containers or CI environments can skip the cert trust step.

## Not changed (intentionally different from upstream)

- **Health checks always exposed** -- Upstream gates `/health` and `/alive` behind `IsDevelopment()`. Our template keeps them unconditional because Azure Container Apps probes them in production.
- **Azure Monitor auto-enabled** -- We enable `UseAzureMonitor()` automatically when `APPLICATIONINSIGHTS_CONNECTION_STRING` is set; upstream leaves it commented out.
- **C# 13 extension blocks in ServiceDefaults** -- Upstream uses traditional extension methods for broader compat; we target net10 intentionally.