### PR TITLE
feat(aspire): add typed response attributes and operation names to controllers

### DIFF
--- a/templates/Aspire/MinimalApi/MinimalApi/Controllers/AuthController.cs
+++ b/templates/Aspire/MinimalApi/MinimalApi/Controllers/AuthController.cs
@@ -12,8 +12,10 @@ public class AuthController(
     SignInManager<ApplicationUser> signInManager,
     UserManager<ApplicationUser> userManager) : ControllerBase
 {
-    [HttpPost("login")]
-    public async Task<IActionResult> Login([FromBody] LoginRequest request)
+    [HttpPost("login", Name = "Login")]
+    [ProducesResponseType<UserInfo>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<UserInfo>> Login([FromBody] LoginRequest request)
     {
         var user = await userManager.FindByEmailAsync(request.Email);
         if (user is null)
@@ -41,8 +43,10 @@ public class AuthController(
         return Unauthorized(new { message = "Invalid email or password" });
     }
 
-    [HttpPost("register")]
-    public async Task<IActionResult> Register([FromBody] RegisterRequest request)
+    [HttpPost("register", Name = "Register")]
+    [ProducesResponseType<UserInfo>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<UserInfo>> Register([FromBody] RegisterRequest request)
     {
         var user = new ApplicationUser { UserName = request.Email, Email = request.Email };
         var result = await userManager.CreateAsync(user, request.Password);
@@ -70,16 +74,18 @@ public class AuthController(
         return BadRequest(new { errors = result.Errors.Select(e => e.Description) });
     }
 
-    [HttpPost("logout")]
+    [HttpPost("logout", Name = "Logout")]
     [Authorize]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<IActionResult> Logout()
     {
         await signInManager.SignOutAsync();
         return NoContent();
     }
 
-    [HttpGet("user")]
-    public IActionResult GetCurrentUser()
+    [HttpGet("user", Name = "GetCurrentUser")]
+    [ProducesResponseType<UserInfo>(StatusCodes.Status200OK)]
+    public ActionResult<UserInfo> GetCurrentUser()
     {
         if (!User.Identity?.IsAuthenticated ?? true)
         {

--- a/templates/Aspire/MinimalApi/MinimalApi/Controllers/RoomsController.cs
+++ b/templates/Aspire/MinimalApi/MinimalApi/Controllers/RoomsController.cs
@@ -15,16 +15,19 @@ public class RoomsController(
     IQuestionService questionService,
     UserManager<ApplicationUser> userManager) : ControllerBase
 {
-    [HttpGet]
-    public async Task<IActionResult> GetAllRooms()
+    [HttpGet(Name = "GetAllRooms")]
+    [ProducesResponseType<IEnumerable<RoomDto>>(StatusCodes.Status200OK)]
+    public async Task<ActionResult<IEnumerable<RoomDto>>> GetAllRooms()
     {
         var rooms = await roomService.GetAllRoomsAsync();
         return Ok(rooms.Select(r => (RoomDto?)r));
     }
 
-    [HttpGet("my")]
+    [HttpGet("my", Name = "GetMyRooms")]
     [Authorize]
-    public async Task<IActionResult> GetMyRooms()
+    [ProducesResponseType<IEnumerable<RoomDto>>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<IEnumerable<RoomDto>>> GetMyRooms()
     {
         var userId = userManager.GetUserId(User);
         if (string.IsNullOrEmpty(userId))
@@ -36,8 +39,10 @@ public class RoomsController(
         return Ok(rooms.Select(r => (RoomDto?)r));
     }
 
-    [HttpGet("{id:guid}")]
-    public async Task<IActionResult> GetRoom(Guid id)
+    [HttpGet("{id:guid}", Name = "GetRoom")]
+    [ProducesResponseType<RoomDto>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<RoomDto>> GetRoom(Guid id)
     {
         var room = await roomService.GetRoomByIdAsync(id);
         if (room == null)
@@ -48,8 +53,10 @@ public class RoomsController(
         return Ok((RoomDto?)room);
     }
 
-    [HttpGet("name/{friendlyName}")]
-    public async Task<IActionResult> GetRoomByName(string friendlyName)
+    [HttpGet("name/{friendlyName}", Name = "GetRoomByName")]
+    [ProducesResponseType<RoomDto>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<RoomDto>> GetRoomByName(string friendlyName)
     {
         var room = await roomService.GetRoomByFriendlyNameAsync(friendlyName);
         if (room == null)
@@ -60,9 +67,11 @@ public class RoomsController(
         return Ok((RoomDto?)room);
     }
 
-    [HttpPost]
+    [HttpPost(Name = "CreateRoom")]
     [Authorize]
-    public async Task<IActionResult> CreateRoom([FromBody] CreateRoomRequest request, CancellationToken cancellationToken)
+    [ProducesResponseType<RoomDto>(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<RoomDto>> CreateRoom([FromBody] CreateRoomRequest request, CancellationToken cancellationToken)
     {
         var userId = userManager.GetUserId(User);
         if (string.IsNullOrEmpty(userId))
@@ -74,8 +83,10 @@ public class RoomsController(
         return CreatedAtAction(nameof(GetRoom), new { id = room.Id }, (RoomDto?)room);
     }
 
-    [HttpDelete("{id:guid}")]
+    [HttpDelete("{id:guid}", Name = "DeleteRoom")]
     [Authorize]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> DeleteRoom(Guid id, CancellationToken cancellationToken)
     {
         var userId = userManager.GetUserId(User);
@@ -88,22 +99,26 @@ public class RoomsController(
         return NoContent();
     }
 
-    [HttpGet("{roomId:guid}/questions")]
-    public async Task<IActionResult> GetQuestions(Guid roomId)
+    [HttpGet("{roomId:guid}/questions", Name = "GetQuestions")]
+    [ProducesResponseType<IEnumerable<QuestionDto>>(StatusCodes.Status200OK)]
+    public async Task<ActionResult<IEnumerable<QuestionDto>>> GetQuestions(Guid roomId)
     {
         var questions = await questionService.GetQuestionsByRoomIdAsync(roomId);
         return Ok(questions.Select(q => (QuestionDto)q));
     }
 
-    [HttpGet("{roomId:guid}/questions/approved")]
-    public async Task<IActionResult> GetApprovedQuestions(Guid roomId)
+    [HttpGet("{roomId:guid}/questions/approved", Name = "GetApprovedQuestions")]
+    [ProducesResponseType<IEnumerable<QuestionDto>>(StatusCodes.Status200OK)]
+    public async Task<ActionResult<IEnumerable<QuestionDto>>> GetApprovedQuestions(Guid roomId)
     {
         var questions = await questionService.GetApprovedQuestionsByRoomIdAsync(roomId);
         return Ok(questions.Select(q => (QuestionDto)q));
     }
 
-    [HttpPost("{roomId:guid}/questions")]
-    public async Task<IActionResult> CreateQuestion(Guid roomId, [FromBody] CreateQuestionRequest request, CancellationToken cancellationToken)
+    [HttpPost("{roomId:guid}/questions", Name = "CreateQuestion")]
+    [ProducesResponseType<QuestionDto>(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status429TooManyRequests)]
+    public async Task<ActionResult<QuestionDto>> CreateQuestion(Guid roomId, [FromBody] CreateQuestionRequest request, CancellationToken cancellationToken)
     {
         // Get client ID from header or generate one
         var clientId = Request.Headers["X-Client-Id"].FirstOrDefault() ?? Guid.NewGuid().ToString();
@@ -123,8 +138,10 @@ public class RoomsController(
         return CreatedAtAction(nameof(GetQuestions), new { roomId }, (QuestionDto)question);
     }
 
-    [HttpPut("{roomId:guid}/questions/{questionId:guid}/approve")]
+    [HttpPut("{roomId:guid}/questions/{questionId:guid}/approve", Name = "ApproveQuestion")]
     [Authorize]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> ApproveQuestion(Guid roomId, Guid questionId, CancellationToken cancellationToken)
     {
         var userId = userManager.GetUserId(User);
@@ -137,8 +154,10 @@ public class RoomsController(
         return NoContent();
     }
 
-    [HttpPut("{roomId:guid}/questions/{questionId:guid}/answer")]
+    [HttpPut("{roomId:guid}/questions/{questionId:guid}/answer", Name = "MarkQuestionAnswered")]
     [Authorize]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> MarkQuestionAnswered(Guid roomId, Guid questionId, CancellationToken cancellationToken)
     {
         var userId = userManager.GetUserId(User);
@@ -151,8 +170,10 @@ public class RoomsController(
         return NoContent();
     }
 
-    [HttpDelete("{roomId:guid}/questions/{questionId:guid}")]
+    [HttpDelete("{roomId:guid}/questions/{questionId:guid}", Name = "DeleteQuestion")]
     [Authorize]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> DeleteQuestion(Guid roomId, Guid questionId, CancellationToken cancellationToken)
     {
         var userId = userManager.GetUserId(User);
@@ -165,8 +186,10 @@ public class RoomsController(
         return NoContent();
     }
 
-    [HttpPut("{roomId:guid}/current-question/{questionId:guid?}")]
+    [HttpPut("{roomId:guid}/current-question/{questionId:guid?}", Name = "SetCurrentQuestion")]
     [Authorize]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> SetCurrentQuestion(Guid roomId, Guid? questionId, CancellationToken cancellationToken)
     {
         var userId = userManager.GetUserId(User);
@@ -179,8 +202,10 @@ public class RoomsController(
         return NoContent();
     }
 
-    [HttpDelete("{roomId:guid}/current-question")]
+    [HttpDelete("{roomId:guid}/current-question", Name = "ClearCurrentQuestion")]
     [Authorize]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> ClearCurrentQuestion(Guid roomId, CancellationToken cancellationToken)
     {
         var userId = userManager.GetUserId(User);

--- a/templates/Aspire/MinimalApi/MinimalApi/Controllers/RoomsController.cs
+++ b/templates/Aspire/MinimalApi/MinimalApi/Controllers/RoomsController.cs
@@ -20,7 +20,7 @@ public class RoomsController(
     public async Task<ActionResult<IEnumerable<RoomDto>>> GetAllRooms()
     {
         var rooms = await roomService.GetAllRoomsAsync();
-        return Ok(rooms.Select(r => (RoomDto?)r));
+        return Ok(rooms.Select(r => (RoomDto)r!));
     }
 
     [HttpGet("my", Name = "GetMyRooms")]
@@ -36,7 +36,7 @@ public class RoomsController(
         }
 
         var rooms = await roomService.GetRoomsByUserIdAsync(userId);
-        return Ok(rooms.Select(r => (RoomDto?)r));
+        return Ok(rooms.Select(r => (RoomDto)r!));
     }
 
     [HttpGet("{id:guid}", Name = "GetRoom")]
@@ -50,7 +50,7 @@ public class RoomsController(
             return NotFound();
         }
 
-        return Ok((RoomDto?)room);
+        return Ok((RoomDto)room!);
     }
 
     [HttpGet("name/{friendlyName}", Name = "GetRoomByName")]
@@ -64,7 +64,7 @@ public class RoomsController(
             return NotFound();
         }
 
-        return Ok((RoomDto?)room);
+        return Ok((RoomDto)room!);
     }
 
     [HttpPost(Name = "CreateRoom")]
@@ -80,7 +80,7 @@ public class RoomsController(
         }
 
         var room = await roomService.CreateRoomAsync(request.FriendlyName, userId, cancellationToken);
-        return CreatedAtAction(nameof(GetRoom), new { id = room.Id }, (RoomDto?)room);
+        return CreatedAtAction(nameof(GetRoom), new { id = room.Id }, (RoomDto)room!);
     }
 
     [HttpDelete("{id:guid}", Name = "DeleteRoom")]
@@ -117,7 +117,7 @@ public class RoomsController(
 
     [HttpPost("{roomId:guid}/questions", Name = "CreateQuestion")]
     [ProducesResponseType<QuestionDto>(StatusCodes.Status201Created)]
-    [ProducesResponseType(StatusCodes.Status429TooManyRequests)]
+    [ProducesResponseType<string>(StatusCodes.Status429TooManyRequests)]
     public async Task<ActionResult<QuestionDto>> CreateQuestion(Guid roomId, [FromBody] CreateQuestionRequest request, CancellationToken cancellationToken)
     {
         // Get client ID from header or generate one


### PR DESCRIPTION
Inspired by the pattern established in [dotnet/aspnetcore#60337](https://github.com/dotnet/aspnetcore/pull/60337) and the upstream `webapi` template, the controllers in the Aspire MinimalApi template were using `IActionResult` everywhere with no type information, meaning the generated OpenAPI spec had empty/unknown response schemas and no stable operation IDs.

## Changes

Both `RoomsController` and `AuthController` now have:

- **`[ProducesResponseType<T>(StatusCodes.StatusXXX)]`** on every action -- OpenAPI now generates accurate response schemas (e.g. `RoomDto[]`, `UserInfo`, `QuestionDto`) instead of empty object stubs. All meaningful status codes are covered (200, 201, 204, 400, 401, 404, 429).
- **`Name = "..."` on each HTTP verb attribute** -- provides stable, readable operation IDs in the OpenAPI spec. This mirrors the `WithName()` pattern used on minimal API endpoints in the upstream templates.
- **Return types changed from `IActionResult` to `ActionResult<T>`** on actions with a typed success response, which reinforces the schema information at the C# level as well.

Build passes with 0 warnings (`-warnaserror`).